### PR TITLE
Add `--only-package` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Options:
                                  May be provided multiple times.
   --group TEXT                   Name of a dependency group to update. May be
                                  provided multiple times.
+  --only-package TEXT            Name of a package to update, while skipping
+                                 all others not specified. May be provided
+                                 multiple times.
   --help                         Show this message and exit.
 ```
 

--- a/src/bump_minimum_dependencies/__init__.py
+++ b/src/bump_minimum_dependencies/__init__.py
@@ -80,6 +80,12 @@ DEFAULT_SKIP_CORE = False
     help="Name of a dependency group to update. May be provided multiple times.",
     multiple=True,
 )
+@click.option(
+    "--only-package",
+    default=[],
+    type=click.STRING,
+    help="Name of a package to update, while skipping all others not specified. May be provided multiple times.",
+)
 def main(
     pyproject_file: str | pathlib.Path,
     drop_months: float,
@@ -90,6 +96,7 @@ def main(
     extra: tuple[str, ...] | list[str],
     group: tuple[str, ...] | list[str],
     skip_package: tuple[str, ...] | list[str],
+    only_package: tuple[str, ...] | list[str],
 ) -> None:
     """Bump the minimum allowed versions of package dependencies."""
 
@@ -106,6 +113,7 @@ def main(
         group=group,
         skip_package=skip_package,
         skip_core=skip_core,
+        only_package=only_package,
     )
 
     bump_minimum_dependencies.run()

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -361,7 +361,9 @@ class BumpMinimumDependencies:
             dependency_group.lower() for dependency_group in group
         ]
         self.packages_to_skip: list[str] = [package.lower() for package in skip_package]
-        self.only_update_these_packages: list[str] = [package.lower() for package in only_package]
+        self.only_update_these_packages: list[str] = [
+            package.lower() for package in only_package
+        ]
 
         try:
             self.pyproject: PyProject = PyProject.load(pyproject_file)
@@ -406,7 +408,10 @@ class BumpMinimumDependencies:
                 continue
             if requirement.name == self.project_name:
                 continue
-            if self.only_update_these_packages and requirement.name not in self.only_update_these_packages:
+            if (
+                self.only_update_these_packages
+                and requirement.name not in self.only_update_these_packages
+            ):
                 continue
             core_requirements_to_update.append(requirement)
 
@@ -454,7 +459,10 @@ class BumpMinimumDependencies:
                 continue
             if requirement.name.lower() in self.packages_to_skip:
                 continue
-            if self.only_update_these_packages and requirement.name.lower() not in self.only_update_these_packages:
+            if (
+                self.only_update_these_packages
+                and requirement.name.lower() not in self.only_update_these_packages
+            ):
                 continue
             requirements_to_update.append(requirement)
 

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -348,6 +348,7 @@ class BumpMinimumDependencies:
         extra: tuple[str, ...] | list[str] = (),
         group: tuple[str, ...] | list[str] = (),
         skip_package: tuple[str, ...] | list[str] = (),
+        only_package: tuple[str, ...] | list[str] = (),
     ):
         self.pyproject_file: str | pathlib.Path = pyproject_file
         self.update_all_optionals: bool = all_extras
@@ -360,6 +361,7 @@ class BumpMinimumDependencies:
             dependency_group.lower() for dependency_group in group
         ]
         self.packages_to_skip: list[str] = [package.lower() for package in skip_package]
+        self.only_update_these_packages: list[str] = [package.lower() for package in only_package]
 
         try:
             self.pyproject: PyProject = PyProject.load(pyproject_file)
@@ -403,6 +405,8 @@ class BumpMinimumDependencies:
             if requirement.name in self.packages_to_skip:
                 continue
             if requirement.name == self.project_name:
+                continue
+            if self.only_update_these_packages and requirement.name not in self.only_update_these_packages:
                 continue
             core_requirements_to_update.append(requirement)
 
@@ -449,6 +453,8 @@ class BumpMinimumDependencies:
             if not isinstance(requirement, Requirement):
                 continue
             if requirement.name.lower() in self.packages_to_skip:
+                continue
+            if self.only_update_these_packages and requirement.name.lower() not in self.only_update_these_packages:
                 continue
             requirements_to_update.append(requirement)
 

--- a/tests/data/bump_only_package/pyproject.expected.toml
+++ b/tests/data/bump_only_package/pyproject.expected.toml
@@ -5,13 +5,14 @@ requires = [ "uv-build>=0.12.2,<0.13" ]
 [project]
 name = "bump-only-package"
 requires-python = ">=3.13"
+version = "0.1.0"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "numpy>2.5",
+  "numpy>=2.5",
   "plasmapy>=0.3.1",
 ]
 optional-dependencies.skip = [
@@ -19,7 +20,7 @@ optional-dependencies.skip = [
   "plasmapy>=0.3.1",
 ]
 optional-dependencies.update = [
-  "numpy>2.5",
+  "numpy>=2.5",
   "plasmapy>=0.3.1",
 ]
 
@@ -29,6 +30,6 @@ skip = [
   "plasmapy>=0.3.1",
 ]
 update = [
-  "numpy>2.5",
+  "numpy>=2.5",
   "plasmapy>=0.3.1",
 ]

--- a/tests/data/bump_only_package/pyproject.expected.toml
+++ b/tests/data/bump_only_package/pyproject.expected.toml
@@ -11,7 +11,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "numpy>1.21",
+  "numpy>2.5",
   "plasmapy>=0.3.1",
 ]
 optional-dependencies.skip = [
@@ -19,7 +19,7 @@ optional-dependencies.skip = [
   "plasmapy>=0.3.1",
 ]
 optional-dependencies.update = [
-  "numpy>1.21",
+  "numpy>2.5",
   "plasmapy>=0.3.1",
 ]
 
@@ -29,6 +29,6 @@ skip = [
   "plasmapy>=0.3.1",
 ]
 update = [
-  "numpy>1.21",
+  "numpy>2.5",
   "plasmapy>=0.3.1",
 ]

--- a/tests/data/bump_only_package/pyproject.expected.toml
+++ b/tests/data/bump_only_package/pyproject.expected.toml
@@ -1,0 +1,34 @@
+[build-system]
+build-backend = "uv_build"
+requires = [ "uv-build>=0.12.2,<0.13" ]
+
+[project]
+name = "bump-only-package"
+requires-python = ">=3.13"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]
+optional-dependencies.skip = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]
+optional-dependencies.update = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]
+
+[dependency-groups]
+skip = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]
+update = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]

--- a/tests/data/bump_only_package/pyproject.toml
+++ b/tests/data/bump_only_package/pyproject.toml
@@ -5,6 +5,7 @@ requires = [ "uv-build>=0.12.2,<0.13" ]
 [project]
 name = "bump-only-package"
 requires-python = ">=3.13"
+version = "0.1.0"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.13",

--- a/tests/data/bump_only_package/pyproject.toml
+++ b/tests/data/bump_only_package/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+build-backend = "uv_build"
+requires = [ "uv-build>=0.12.2,<0.13" ]
+
+[project]
+name = "bump-only-package"
+requires-python = ">=3.13"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]
+optional-dependencies.skip = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]
+optional-dependencies.update = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]
+
+[dependency-groups]
+skip = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]
+update = [
+  "numpy>1.21",
+  "plasmapy>=0.3.1",
+]

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -77,7 +77,13 @@ def get_errmsg_from_file_comparison(
         (
             "bump_only_package",
             "2026-08-17",
-            {"drop_months": 0, "cooldown_months": 0, "group": ["update"], "extra": ["update"], "only_package": ["numpy"]}
+            {
+                "drop_months": 0,
+                "cooldown_months": 0,
+                "group": ["update"],
+                "extra": ["update"],
+                "only_package": ["numpy"],
+            },
         ),
         (
             "astropy",

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -75,6 +75,11 @@ def get_errmsg_from_file_comparison(
             {"drop_months": 24, "cooldown_months": 21, "group": ["astropy", "numpy"]},
         ),
         (
+            "bump_only_package",
+            "2026-08-17",
+            {"drop_months": 0, "cooldown_months": 0, "group": ["update"], "extra": ["update"], "only_package": ["numpy"]}
+        ),
+        (
             "astropy",
             "2026-08-17",
             {


### PR DESCRIPTION
This adds the capability to update only a particular package in a way that is interoperable with the other options.

I added a test case that also checks interoperability with `--group` and `--extra`.

Closes #16.