### PR TITLE
Change ordering of flags and update cooldown months to be ≤ drop_months

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,35 +34,36 @@ Usage: bump-minimum-dependencies [OPTIONS]
 
   For example, if version `3.4.0` of a package dependency was released 25
   months ago and version `3.5.0` was released 23 months ago, running `bump-
-  minimum-dependencies` will change a requirement specifier of that package
-  from `>=3.4.0` to `>=3.5.0`.
+  minimum-dependencies` will update the requirement from `>=3.4.0` to
+  `>=3.5.0`.
 
   Requirements with markers or that cannot be updated will be skipped with a
   warning.
 
 Options:
-  --pyproject-file FILE          Path to pyproject.toml. Defaults to
+  --pyproject-file FILE          Path to pyproject.toml. Default is
                                  pyproject.toml in current directory.
-  --skip-package TEXT            Name of a package to skip when performing
-                                 updates. May be provided multiple times.
-  --drop-months FLOAT RANGE      Drop minor releases from this many months
-                                 ago. Defaults to 24.  [x>=0]
+  --drop-months FLOAT RANGE      Drop minor releases older than this many
+                                 months ago. Defaults to 24.  [x>=0]
   --cooldown-months FLOAT RANGE  Ensure that there is at least one release
                                  this many months old, if possible. Defaults
-                                 to 12.  [x>=0]
-  --all-extras                   Flag to update all optional dependencies.
-                                 Defaults to false.
-  --all-groups                   Flag to update all dependency groups.
-                                 Defaults to false.
-  --skip-core                    Flag to skip updating core project
-                                 dependencies. Defaults to false.
-  --extra TEXT                   Name of an optional dependencies category.
-                                 May be provided multiple times.
+                                 to 12 or the value provided to --drop-months,
+                                 whichever is smaller.  [x>=0]
+  --only-package TEXT            Name of a package to update. May be provided
+                                 multiple times. When this option is used, all
+                                 other packages will be skipped.
+  --skip-package TEXT            Name of a package to skip when performing
+                                 updates. May be provided multiple times.
+  --extra TEXT                   Name of an optional dependencies category to
+                                 update. May be provided multiple times.
+  --all-extras                   If provided, all optional dependency
+                                 categories will be updated.
   --group TEXT                   Name of a dependency group to update. May be
                                  provided multiple times.
-  --only-package TEXT            Name of a package to update, while skipping
-                                 all others not specified. May be provided
-                                 multiple times.
+  --all-groups                   If provided, all dependency groups will be
+                                 updated.
+  --skip-core                    If provided, core project dependencies will
+                                 not be updated.
   --help                         Show this message and exit.
 ```
 
@@ -72,6 +73,12 @@ To bump core package dependencies using default settings, run:
 
 ```shell
 bump-minimum-dependencies
+```
+
+To bump only plasmapy, run:
+
+```shell
+bump-minimum-dependencies --only-package plasmapy
 ```
 
 To skip updates for numpy and plasmapy, run:

--- a/src/bump_minimum_dependencies/__init__.py
+++ b/src/bump_minimum_dependencies/__init__.py
@@ -124,8 +124,7 @@ def main(
     with a warning.
     """
 
-    if cooldown_months > drop_months:
-        raise click.BadParameter("cooldown_months cannot exceed drop_months.")
+    cooldown_months = min(cooldown_months, drop_months)
 
     bump_minimum_dependencies = bump.BumpMinimumDependencies(
         pyproject_file=pyproject_file,

--- a/src/bump_minimum_dependencies/__init__.py
+++ b/src/bump_minimum_dependencies/__init__.py
@@ -19,23 +19,20 @@ DEFAULT_SKIP_CORE = False
     "--pyproject-file",
     default="pyproject.toml",
     type=click.Path(
-        exists=True, file_okay=True, dir_okay=False, writable=True, readable=True
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        writable=True,
+        readable=True,
     ),
-    help="Path to pyproject.toml. Defaults to pyproject.toml in current directory.",
-)
-@click.option(
-    "--skip-package",
-    default=[],
-    type=click.STRING,
-    help="Name of a package to skip when performing updates. May be provided multiple times.",
-    multiple=True,
+    help="Path to pyproject.toml. Default is pyproject.toml in current directory.",
 )
 @click.option(
     "--drop-months",
     default=DEFAULT_DROP_MONTHS,
     type=click.FloatRange(min=0, max_open=True),
     help=(
-        f"Drop minor releases from this many months ago. Defaults "
+        f"Drop minor releases older than this many months ago. Defaults "
         f"to {DEFAULT_DROP_MONTHS}."
     ),
 )
@@ -45,33 +42,38 @@ DEFAULT_SKIP_CORE = False
     type=click.FloatRange(min=0, max_open=True),
     help=(
         f"Ensure that there is at least one release this many months "
-        f"old, if possible. Defaults to {DEFAULT_COOLDOWN_MONTHS}."
+        f"old, if possible. Defaults to {DEFAULT_COOLDOWN_MONTHS} or "
+        f"the value provided to --drop-months, whichever is smaller."
     ),
 )
 @click.option(
-    "--all-extras",
-    default=False,
-    is_flag=True,
-    help="Flag to update all optional dependencies. Defaults to false.",
+    "--only-package",
+    default=[],
+    type=click.STRING,
+    help=(
+        "Name of a package to update. May be provided multiple times. "
+        "When this option is used, all other packages will be skipped."
+    ),
 )
 @click.option(
-    "--all-groups",
-    default=False,
-    is_flag=True,
-    help="Flag to update all dependency groups. Defaults to false.",
-)
-@click.option(
-    "--skip-core",
-    default=False,
-    is_flag=True,
-    help="Flag to skip updating core project dependencies. Defaults to false.",
+    "--skip-package",
+    default=[],
+    type=click.STRING,
+    help="Name of a package to skip when performing updates. May be provided multiple times.",
+    multiple=True,
 )
 @click.option(
     "--extra",
     default=[],
     type=click.STRING,
-    help="Name of an optional dependencies category. May be provided multiple times.",
+    help="Name of an optional dependencies category to update. May be provided multiple times.",
     multiple=True,
+)
+@click.option(
+    "--all-extras",
+    default=False,
+    is_flag=True,
+    help="If provided, all optional dependency categories will be updated.",
 )
 @click.option(
     "--group",
@@ -81,10 +83,16 @@ DEFAULT_SKIP_CORE = False
     multiple=True,
 )
 @click.option(
-    "--only-package",
-    default=[],
-    type=click.STRING,
-    help="Name of a package to update, while skipping all others not specified. May be provided multiple times.",
+    "--all-groups",
+    default=False,
+    is_flag=True,
+    help="If provided, all dependency groups will be updated.",
+)
+@click.option(
+    "--skip-core",
+    default=False,
+    is_flag=True,
+    help="If provided, core project dependencies will not be updated.",
 )
 def main(
     pyproject_file: str | pathlib.Path,
@@ -109,8 +117,8 @@ def main(
 
     For example, if version `3.4.0` of a package dependency was released
     25 months ago and version `3.5.0` was released 23 months ago,
-    running `bump-minimum-dependencies` will change a requirement
-    specifier of that package from `>=3.4.0` to `>=3.5.0`.
+    running `bump-minimum-dependencies` will update the requirement from
+    `>=3.4.0` to `>=3.5.0`.
 
     Requirements with markers or that cannot be updated will be skipped
     with a warning.

--- a/src/bump_minimum_dependencies/__init__.py
+++ b/src/bump_minimum_dependencies/__init__.py
@@ -124,8 +124,6 @@ def main(
     with a warning.
     """
 
-    cooldown_months = min(cooldown_months, drop_months)
-
     bump_minimum_dependencies = bump.BumpMinimumDependencies(
         pyproject_file=pyproject_file,
         drop_months=drop_months,

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -350,6 +350,14 @@ class BumpMinimumDependencies:
         skip_package: tuple[str, ...] | list[str] = (),
         only_package: tuple[str, ...] | list[str] = (),
     ):
+        if cooldown_months > drop_months:
+            # issue a warning when cooldown_months ≠ the default value
+            if cooldown_months != 12:
+                msg = f"Reducing cooldown_months to {drop_months} to equal drop_months."
+                logger.warning(msg)
+
+            cooldown_months = drop_months
+
         self.pyproject_file: str | pathlib.Path = pyproject_file
         self.update_all_optionals: bool = all_extras
         self.update_all_dependency_groups: bool = all_groups


### PR DESCRIPTION
 - I reordered the order of the click decorators to be a bit more intuitive.  The options are not alphabetical, but sorted conceptually (or in pseudocode: `sorted(options, key=lambda x: 🧠(x))`).  
 - I made it so that `cooldown_months` is lowered to `drop_months` if `cooldown_months` exceeds `drop_months`.  When `cooldown_months` differs from its default value of `12`, a logger warning notes that its value is reduced to `drop_months`.