### PR TITLE
Test against the CLI and fix a bug that prevented the CLI from updating packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,32 +31,27 @@ jobs:
 
     strategy:
       fail-fast: false
-
       matrix:
         include:
-
-        - nox_session: lint
+        - nox_session: test_cli-3.13
+        - nox_session: test_cli-3.14
         - nox_session: test-3.13
         - nox_session: test-3.14
         - nox_session: ty
+        - nox_session: lint
         - nox_session: build
         - nox_session: run
-
     steps:
-
     - name: Checkout code
       uses: actions/checkout@v5
       with:
         persist-credentials: false
-
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
         activate-environment: true
         enable-cache: true
         cache-suffix: ${{ matrix.nox_session }}
-
     - run: uv pip install . --group dev
-
     - name: Run the check
       run: nox -s '${{ matrix.nox_session }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,10 @@ jobs:
         enable-cache: true
         cache-suffix: ${{ matrix.nox_session }}
     - run: uv pip install . --group dev
+    - name: Install faketime (requires Ubuntu)
+      if: contains(matrix.nox_session, 'cli')
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y faketime
     - name: Run the check
       run: nox -s '${{ matrix.nox_session }}'

--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ bump-minimum-dependencies --extra dev
   - Use non-standard [version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers).
   - Have resulting requirements with multiple `!=` operators (as of `dep-logic==0.7.1`).
 
-- This tool does _not_ guarantee that an environment can be created that includes the minimum allowed versions of all direct dependencies (such as when updates are skipped for a dependency without a minimum allowed version).
+- This tool does not guarantee that an environment can be created that includes the minimum allowed versions of all direct dependencies, but this can be tested with `uv lock --resolution=lowest-direct --dry-run`.
 
-  - Run `uv lock --dry-run` to test that the requirements can produce a self-consistent environment.
+- This tool does not update `build-system.requires`.
+
+- README and license files declared in `pyproject.toml` must be present so that `pyproject.toml` due to an upstream limitation with [pyproject-parser.PyProject.load()](https://pyproject-parser.readthedocs.io/en/latest/api/pyproject-parser.html#pyproject_parser.PyProject.load).
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -112,16 +112,15 @@ bump-minimum-dependencies --extra dev
 
 - If the time-based requirement is mutually exclusive with the original requirement, the original requirement will be preserved.
 
-- If a particular requirement cannot be updated, it will be skipped with a warning.
+- If a particular requirement cannot be updated, it will be skipped.
 
 - Within a given category, dependencies with markers (such as `'setuptools; python_version > "3.11"'`) will not be updated.
 
-- Requirements may be normalized upon updates by `uv add`. Opinionated autoformatters [pyproject-fmt](https://pyproject-fmt.readthedocs.io/en/latest/index.html) will reduce or eliminate the need for requirements normalization. Example normalizations include:
+- Requirements may be normalized upon updates by `uv add`. Opinionated autoformatters like [pyproject-fmt](https://pyproject-fmt.readthedocs.io/en/latest/index.html) reduce the need for requirements normalization. Example normalizations include:
 
   - `.0` suffixes may be removed, since `X.Y` and `X.Y.0` "are not considered distinct release numbers" as per [PEP 440](https://peps.python.org/pep-0440).
-  - Package names, which are case-insensitive, may be made lower case.
+  - Package names may be made lower case.
   - Single quotes may be changed to double quotes.
-  - Changes to spacing, indentation, and line breaks.
 
 ## Limitations and caveats
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,6 @@
 
 Automatically bump the minimum allowed minor versions of Python package dependencies based on the time since first release, with a cooldown period.
 
-## Motivation
-
-Determining the minimum allowed version of a dependency requires balancing competing tradeoffs. ⚖️
-Supporting older versions increases maintenance burden because of the need to support and test a wide range of versions, while also limiting developers from using newer features and assuming bugfixes.
-When the range of allowed versions is too large, code can become more complicated to account for various contingencies.
-Support windows that are too brief increase the risk of dependency conflicts and may cause problems for end users.
-The developer maintenance burden is further increased when developers repeatedly discuss when to drop older versions of dependencies.
-
-[SPEC 0] recommends that projects across the scientific pythoniverse adopt a common time-based policy for dropping support for older versions of dependencies.
-SPEC 0 recommends core package dependencies be dropped 24 months after their initial minor release.
-NumPy `v2.1.0` was released on 2024-08-18, so SPEC 0 recommends that packages drop support for `v2.1.*` of NumPy after 2026-08-18.
-
-A limitation of SPEC 0 is that when a dependency goes more than 24 months between releases, a new release can immediately become the minimum supported version.
-This limitation can be mitigated by providing a cooldown period so that new releases do not become the minimum supported version until a certain time period has passed (such as 12 months).
-
-Because dependency updates have often needed to be performed manually (such as by looking up release times on the Python Package Index and editing `pyproject.toml` accordingly), a tool that automates these updates will save developer time, especially when accounting for edge cases.
-
 ## Usage
 
 ```groff
@@ -151,13 +134,22 @@ bump-minimum-dependencies --extra dev
 
   - Run `uv lock --dry-run` to test that the requirements can produce a self-consistent environment.
 
-  - Run `uv lock --resolution=lowest-direct --dry-run` to test that the minimum allowed versions of direct dependencies can produce a self-consistent environment.
+## Motivation
 
-- This tool does not update `build-system.requires`, as these updates cannot be performed with `uv add` as of `uv==0.12.5`.
+Determining the minimum allowed version of a dependency requires balancing competing tradeoffs. ⚖️
+Supporting older versions increases maintenance burden because of the need to support and test a wide range of versions, while also limiting developers from using newer features and assuming bugfixes.
+When the range of allowed versions is too large, code can become more complicated to account for various contingencies.
+Support windows that are too brief increase the risk of dependency conflicts and may cause problems for end users.
+The developer maintenance burden is further increased when developers repeatedly discuss when to drop older versions of dependencies.
 
-- If README and/or license files are declared in `pyproject.toml`, they must be present so that `pyproject.toml` can be loaded by [pyproject-parser.PyProject.load()](https://pyproject-parser.readthedocs.io/en/latest/api/pyproject-parser.html#pyproject_parser.PyProject.load).
+[SPEC 0] recommends that projects across the scientific pythoniverse adopt a common time-based policy for dropping support for older versions of dependencies.
+SPEC 0 recommends core package dependencies be dropped 24 months after their initial minor release.
+NumPy `v2.1.0` was released on 2024-08-18, so SPEC 0 recommends that packages drop support for `v2.1.*` of NumPy after 2026-08-18.
 
-- This tool does not upgrade the minimum required version of Python.
+A limitation of SPEC 0 is that when a dependency goes more than 24 months between releases, a new release can immediately become the minimum supported version.
+This limitation can be mitigated by providing a cooldown period so that new releases do not become the minimum supported version until a certain time period has passed (such as 12 months).
+
+Because dependency updates have often needed to be performed manually (such as by looking up release times on the Python Package Index and editing `pyproject.toml` accordingly), a tool that automates these updates will save developer time, especially when accounting for edge cases.
 
 ## Feature requests and bug reports
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,9 +58,11 @@ def run(session: nox.Session) -> None:
 
 @nox.session(python=supported_python_versions)
 def test_cli(session: nox.Session):
+    """Test the command line interface."""
     session.install(".")
 
     session.run_install("bump-minimum-dependencies", "--version")
+    session.run_install("faketime", "--version", external=True)
 
     tmp_dir = Path(session.create_tmp())
     source_dir = Path("tests/data/base_case")

--- a/noxfile.py
+++ b/noxfile.py
@@ -63,31 +63,24 @@ def test_cli(session: nox.Session):
     session.run_install("bump-minimum-dependencies", "--version")
 
     tmp_dir = Path(session.create_tmp())
-    source_dir = Path("tests/data/astropy")
-    target_dir = tmp_dir / "astropy"
+    source_dir = Path("tests/data/base_case")
+    target_dir = tmp_dir / "base_case"
     shutil.copytree(source_dir, target_dir)
     session.chdir(target_dir)
 
     bump_command = [
         "bump-minimum-dependencies",
-        "--drop-months=12",
-        "--cooldown-months=6",
-        "--all-groups",
-        "--all-extras",
+        "--drop-months=24",
+        "--cooldown-months=21",
     ]
 
     # Prepend faketime CLI wrapper to intercept child process OS calls
     session.run(
         "faketime",
-        "2026-08-17",
+        "2026-01-01",
         *bump_command,
         external=True,
     )
-
-    # result = "pyproject.toml"
-    # expected = "pyproject.expected.toml"
-
-    # session.run("diff", "pyproject.toml", "pyproject.expected.toml", external=True)
 
     result = Path("pyproject.toml").read_text().splitlines(keepends=True)
     expected = Path("pyproject.expected.toml").read_text().splitlines(keepends=True)
@@ -96,13 +89,13 @@ def test_cli(session: nox.Session):
         return
 
     diff = list(
-        difflib.unified_diff(
-            result, expected, fromfile=str(result), tofile=str(expected)
-        )
-    )
+         difflib.unified_diff(
+             result, expected, fromfile=str(result), tofile=str(expected)
+         )
+     )
 
     for x in diff[2:]:
-        print(x.removesuffix("\n"))
+         print(x.removesuffix("\n"))
 
     session.error(
         "The resulting pyproject.toml does not match pyproject.expected.toml."

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,13 +89,13 @@ def test_cli(session: nox.Session):
         return
 
     diff = list(
-         difflib.unified_diff(
-             result, expected, fromfile=str(result), tofile=str(expected)
-         )
-     )
+        difflib.unified_diff(
+            result, expected, fromfile=str(result), tofile=str(expected)
+        )
+    )
 
     for x in diff[2:]:
-         print(x.removesuffix("\n"))
+        print(x.removesuffix("\n"))
 
     session.error(
         "The resulting pyproject.toml does not match pyproject.expected.toml."

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,6 @@ def run(session: nox.Session) -> None:
 @nox.session(python=supported_python_versions)
 def test_cli(session: nox.Session):
     session.install(".")
-    # session.install("tokenize_rt")
 
     session.run_install("bump-minimum-dependencies", "--version")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,13 +3,16 @@
 # dependencies = ["nox", "nox-uv"]
 # ///
 
+import difflib
+import filecmp
+import shutil
 import nox
 import nox_uv
-import pathlib
+from pathlib import Path
 
 nox.options.default_venv_backend = "uv"
 
-_HERE = pathlib.Path(__file__).parent
+_HERE = Path(__file__).parent
 
 supported_python_versions: tuple[str, ...] = ("3.13", "3.14")
 maxpython: str = sorted(supported_python_versions)[-1]
@@ -51,6 +54,60 @@ def run(session: nox.Session) -> None:
     """Run the package."""
     session.install(".")
     session.run("bump-minimum-dependencies")
+
+
+@nox.session(python=supported_python_versions)
+def test_cli(session: nox.Session):
+    session.install(".")
+    # session.install("tokenize_rt")
+
+    session.run_install("bump-minimum-dependencies", "--version")
+
+    tmp_dir = Path(session.create_tmp())
+    source_dir = Path("tests/data/astropy")
+    target_dir = tmp_dir / "astropy"
+    shutil.copytree(source_dir, target_dir)
+    session.chdir(target_dir)
+
+    bump_command = [
+        "bump-minimum-dependencies",
+        "--drop-months=12",
+        "--cooldown-months=6",
+        "--all-groups",
+        "--all-extras",
+    ]
+
+    # Prepend faketime CLI wrapper to intercept child process OS calls
+    session.run(
+        "faketime",
+        "2026-08-17",
+        *bump_command,
+        external=True,
+    )
+
+    # result = "pyproject.toml"
+    # expected = "pyproject.expected.toml"
+
+    # session.run("diff", "pyproject.toml", "pyproject.expected.toml", external=True)
+
+    result = Path("pyproject.toml").read_text().splitlines(keepends=True)
+    expected = Path("pyproject.expected.toml").read_text().splitlines(keepends=True)
+
+    if filecmp.cmp("pyproject.toml", "pyproject.expected.toml", shallow=False):
+        return
+
+    diff = list(
+        difflib.unified_diff(
+            result, expected, fromfile=str(result), tofile=str(expected)
+        )
+    )
+
+    for x in diff[2:]:
+        print(x.removesuffix("\n"))
+
+    session.error(
+        "The resulting pyproject.toml does not match pyproject.expected.toml."
+    )
 
 
 if __name__ == "__main__":

--- a/src/bump_minimum_dependencies/__init__.py
+++ b/src/bump_minimum_dependencies/__init__.py
@@ -55,6 +55,7 @@ DEFAULT_SKIP_CORE = False
         "Name of a package to update. May be provided multiple times. "
         "When this option is used, all other packages will be skipped."
     ),
+    multiple=True,
 )
 @click.option(
     "--skip-package",


### PR DESCRIPTION
This PR adds a Nox session to test the CLI, and fixes an error in a click decorator that prevented the CLI from making any updates (which is the reason by `bump-minimum-dependencies==0.2.0` was yanked).  In particular, I did not set `multiple=True` for the `--only-package` option, which led to the option getting converted into a string (`"[]"`) instead of a list (`[]`).  Sigh!  This will be fixed in 0.3.0.

> [!IMPORTANT]
> Always test the CLI! 😅

