### PR TITLE
Improve robustness and exception handling

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,13 @@ maxpython: str = sorted(supported_python_versions)[-1]
 @nox_uv.session(python=maxpython, uv_groups=["dev"])
 def lint(session: nox.Session) -> None:
     """Run prek on all files."""
-    session.run("prek", "run", "--all-files", "--quiet")
+    session.run(
+        "prek",
+        "run",
+        "--all-files",
+        "--quiet",
+        *session.posargs,
+    )
 
 
 @nox_uv.session(python=supported_python_versions, uv_groups=["dev"])
@@ -44,6 +50,7 @@ def test(session: nox.Session) -> None:
         "--tb=short",
         "--doctest-modules",
         "--doctest-continue-on-failure",
+        *session.posargs,
     )
 
 
@@ -57,14 +64,14 @@ def ty(session: nox.Session) -> None:
 @nox.session(python=supported_python_versions)
 def build(session: nox.Session) -> None:
     """Build the package."""
-    session.run("uv", "build")
+    session.run("uv", "build", *session.posargs)
 
 
 @nox.session(python=supported_python_versions)
 def run(session: nox.Session) -> None:
     """Run the package."""
     session.install(".")
-    session.run("bump-minimum-dependencies")
+    session.run("bump-minimum-dependencies", session.posargs)
 
 
 @nox.session(python=supported_python_versions)
@@ -87,7 +94,6 @@ def test_cli(session: nox.Session) -> None:
         "--cooldown-months=21",
     ]
 
-    # Prepend faketime CLI wrapper to intercept child process OS calls
     session.run(
         "faketime",
         "2026-01-01",

--- a/noxfile.py
+++ b/noxfile.py
@@ -304,9 +304,8 @@ def download_pyprojects(session: nox.Session) -> None:
         "django/django",
         "fastapi/fastapi",
         "home-assistant/core",
-        "indygreg/python-build-standalone",  # does not run cleanly
-        "matplotlib/matplotlib",  # error; multiple entries for vtk
-        "numpy/numpy",
+        "indygreg/python-build-standalone",
+        "matplotlib/matplotlib",
         "pallets/flask",
         "pandas-dev/pandas",
         "PlasmaPy/PlasmaPy",
@@ -314,14 +313,13 @@ def download_pyprojects(session: nox.Session) -> None:
         "pytest-dev/pytest",
         "python-poetry/poetry",
         "pytorch/pytorch",
-        "pyvista/pyvista",  # does not run cleanly
+        "pyvista/pyvista",
         "scikit-image/scikit-image",
         "scikit-learn/scikit-learn",
         "scipy/scipy",
-        "sqlalchemy/sqlalchemy",  # does not run cleanly
+        "sqlalchemy/sqlalchemy",  # failed to parse pyproject.toml
         "sunpy/sunpy",
-        "yt-project/yt",  # fails but not cleanly
-        "namurphy/bump-minimum-dependencies",
+        "yt-project/yt",
     ]
 
     for repository in repositories:

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,7 +71,7 @@ def build(session: nox.Session) -> None:
 def run(session: nox.Session) -> None:
     """Run the package."""
     session.install(".")
-    session.run("bump-minimum-dependencies", session.posargs)
+    session.run("bump-minimum-dependencies", *session.posargs)
 
 
 @nox.session(python=supported_python_versions)

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -395,10 +395,10 @@ class BumpMinimumDependencies:
         return self.pyproject.project_name
 
     @property
-    def core_requirements_to_update(self) -> list[Requirement]:
+    def core_requirements_to_update(self) -> set[Requirement]:
         """Core project dependencies to be updated if necessary."""
         if self.skip_core_requirements:
-            return []
+            return set()
 
         try:
             all_requirements = self.pyproject.core_requirements
@@ -406,7 +406,7 @@ class BumpMinimumDependencies:
             errmsg = f"Unable to access dependencies in {self.pyproject_file!r}"
             raise click.ClickException(errmsg) from exc
 
-        core_requirements_to_update: list[Requirement] = []
+        core_requirements_to_update: set[Requirement] = set()
         for requirement in all_requirements:
             if requirement.name in self.packages_to_skip:
                 continue

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -460,8 +460,19 @@ class BumpMinimumDependencies:
     ) -> list[str]:
         requirements_to_update: list[Requirement] = []
         for requirement in requirements:
+            # The following error-handling code should never be reached,
+            # and is intended as a safeguard.
             if not isinstance(requirement, Requirement):
-                logger.warning(f"{requirement = } is not a Requirement")
+                try:
+                    logger.warning(f"{requirement = } is not a Requirement object.")
+                    requirement = Requirement(requirement)
+                except (InvalidRequirement, TypeError):
+                    logger.error(
+                        f"{requirement = } cannot be converted into a "
+                        f"Requirement. Continuing"
+                    )
+                    continue
+
             if requirement.name.lower() in self.packages_to_skip:
                 continue
 

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -215,7 +215,10 @@ class BumpPackage:
         minimum_allowed_requirement = utils.normalize_requirement_string(
             min(
                 supported_releases_before_cooldown,
-                default=max(releases_before_drop_date),
+                default=max(
+                    releases_before_drop_date,
+                    default=min(self.minor_releases),
+                ),
             )
         )
 
@@ -504,13 +507,18 @@ class BumpMinimumDependencies:
                     cooldown_months=self.cooldown_months,
                 )
 
-            # Catch any exception since if a package cannot be updated
+            except requests.exceptions.JSONDecodeError:
+                logger.warning(
+                    f"Unable to access release metadata for {requirement} from"
+                    f"the Python Package Index; skipping.",
+                )
+            # Catch all other exceptions since if a package cannot be updated
             # for whatever reason, it should be skipped with a warning issued.
-            except Exception:
+            except Exception as exc_info:
                 warning_message = (
                     f"Unable to update dependency {requirement}. Skipping."
                 )
-                logger.warning(warning_message)
+                logger.warning(warning_message, exc_info=exc_info)
             else:
                 if not new_requirement:
                     continue

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -193,7 +193,7 @@ class BumpPackage:
                 release_date: datetime.date = self.versions_to_release_dates[release]
             except KeyError:
                 logger.info(
-                    f"{self.name} {str(release)} is not in the "
+                    f"Version {str(release)} of {self.name}  is not in the "
                     f"mapping from versions to release dates, possibly due "
                     f"to non-standard versioning or that the release was "
                     f"yanked or a prerelease. Continuing."
@@ -206,14 +206,15 @@ class BumpPackage:
                 releases_before_drop_date.append(release)
 
         if not supported_releases_before_cooldown:
-            logger.debug("No supported releases before cooldown.")
+            logger.debug(
+                f"No supported releases before cooldown. [{self.name}]")
 
         if not releases_before_drop_date:
-            logger.debug("No releases before dropdate.")
+            logger.debug(f"No releases before drop date. [{self.name}]")
 
         # when a package's first release is during the cooldown period
         if not supported_releases_before_cooldown and not releases_before_drop_date:
-            logger.debug("First release of package is during the cooldown period")
+            logger.debug(f"First release is during the cooldown period. [{self.name}]")
             return utils.normalize_requirement_string(min(self.released_versions))
 
         minimum_allowed_requirement = utils.normalize_requirement_string(
@@ -223,8 +224,8 @@ class BumpPackage:
             )
         )
 
-        logger.debug(
-            f"Oldest supported release of {self.name} is {minimum_allowed_requirement}"
+        logger.info(
+            f"Oldest supported release: {minimum_allowed_requirement} [{self.name}]"
         )
 
         return minimum_allowed_requirement

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -9,7 +9,6 @@ __all__ = [
 
 import pathlib
 
-import click
 import requests
 
 from dep_logic.specifiers import parse_version_specifier
@@ -408,9 +407,11 @@ class BumpMinimumDependencies:
 
         try:
             all_requirements = self.pyproject.project["dependencies"]  # ty:ignore[not-subscriptable]
-        except (TypeError, AttributeError, KeyError) as exc:
-            errmsg = f"Unable to access dependencies in {self.pyproject_file!r}"
-            raise click.ClickException(errmsg) from exc
+        except (TypeError, AttributeError, KeyError):
+            errmsg = (
+                f"Unable to access dependencies in {self.pyproject_file!r}; skipping."
+            )
+            return []
 
         core_requirements_to_update: list[Requirement] = []
         for requirement in all_requirements:

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -408,9 +408,6 @@ class BumpMinimumDependencies:
         try:
             all_requirements = self.pyproject.project["dependencies"]  # ty:ignore[not-subscriptable]
         except (TypeError, AttributeError, KeyError):
-            errmsg = (
-                f"Unable to access dependencies in {self.pyproject_file!r}; skipping."
-            )
             return []
 
         core_requirements_to_update: list[Requirement] = []

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -560,9 +560,6 @@ class BumpMinimumDependencies:
 
     def bump_core_requirements(self) -> None:
         """Bump the core package requirements."""
-        if self.skip_core_requirements:
-            return
-
         new_requirements = self.get_new_requirements(self.core_requirements_to_update)
         self.run_uv_commands(new_requirements)
 

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -575,13 +575,8 @@ class BumpMinimumDependencies:
         if not self.update_all_optionals and not self.optional_categories_to_update:
             return
 
-        optionals = self.pyproject.project.get("optional-dependencies")  # ty:ignore[unresolved-attribute]
-        if not optionals:
-            logger.info("No optional dependencies found.")
-            return
-
         for category in self.optional_categories_to_update:
-            requirements = optionals[category]
+            requirements = self.pyproject.optional_dependencies[category]
             new_requirements = self.get_new_requirements(requirements)  # ty:ignore[invalid-argument-type]
             self.run_uv_commands(new_requirements, extras_category=category)
 

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -386,7 +386,7 @@ class BumpMinimumDependencies:
         try:
             self.pyproject: PyProject = PyProject(pyproject_file)
         except FileNotFoundError as exc:
-            msg = f"Unable to load {pyproject_file}. Stopping."
+            msg = f"Cannot load {pyproject_file}. Stopping."
             raise click.ClickException(msg) from exc
 
         if self.project_name:
@@ -516,16 +516,16 @@ class BumpMinimumDependencies:
                                "from PyPI; skipping.")
             except requests.exceptions.JSONDecodeError:
                 logger.warning(
-                    f"Unable to access release metadata for {requirement} from"
-                    f"the Python Package Index; skipping.",
+                    f"[{requirement.name}] Cannot access metadata from "
+                    f"PyPI; skipping.",
                 )
             # Catch all other exceptions since if a package cannot be updated
             # for whatever reason, it should be skipped with a warning issued.
-            except Exception as exc_info:
+            except Exception:
                 warning_message = (
-                    f"Unable to update dependency {requirement}. Skipping."
+                    f"[{requirement.name}] Unable to update requirement. Skipping."
                 )
-                logger.warning(warning_message, exc_info=exc_info)
+                logger.warning(warning_message)
             else:
                 if not new_requirement:
                     continue

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -587,7 +587,7 @@ class BumpMinimumDependencies:
             logger.info(msg)
 
             try:
-                result = subprocess.run(
+                subprocess.run(
                     command,
                     check=True,
                     capture_output=True,
@@ -597,6 +597,7 @@ class BumpMinimumDependencies:
                     f"Command failed: {command_string}",
                     exc_info=exc_info,
                 )
+                logger.warning(f"Update not performed: {new_requirement}. Continuing.")
 
     def bump_core_requirements(self) -> None:
         """Bump the core package requirements."""

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -522,7 +522,7 @@ class BumpMinimumDependencies:
 
         return new_requirements
 
-    def run_uv_command(
+    def run_uv_commands(
         self,
         new_requirements: list[str],
         *,
@@ -547,18 +547,21 @@ class BumpMinimumDependencies:
             logger.info(msg)
             return
 
-        command = [
-            "uv",
-            "add",
-            "--frozen",
-            "--quiet",
-            *flag,
-            *new_requirements,
-        ]
+        for new_requirement in new_requirements:
+            # Run a separate `uv add` command for each requirement
+            # so that the other updates will be performed.
+            command = [
+                "uv",
+                "add",
+                "--frozen",
+                "--quiet",
+                *flag,
+                new_requirement,
+            ]
 
-        msg = f"Running: {' '.join(command)}"
-        logger.info(msg)
-        subprocess.run(command)
+            msg = f"Running: {' '.join(command)}"
+            logger.info(msg)
+            subprocess.run(command)
 
     def bump_core_requirements(self) -> None:
         """Bump the core package requirements."""
@@ -566,7 +569,7 @@ class BumpMinimumDependencies:
             return
 
         new_requirements = self.get_new_requirements(self.core_requirements_to_update)
-        self.run_uv_command(new_requirements)
+        self.run_uv_commands(new_requirements)
 
     def bump_dependency_groups(self):
         """Bump requirements in dependency groups."""
@@ -576,7 +579,7 @@ class BumpMinimumDependencies:
         for dependency_group in self.dependency_groups_to_update:
             requirements = self.pyproject.dependency_groups[dependency_group]  # ty:ignore[not-subscriptable]
             new_requirements = self.get_new_requirements(requirements)  # ty:ignore[invalid-argument-type]
-            self.run_uv_command(new_requirements, dependency_group=dependency_group)
+            self.run_uv_commands(new_requirements, dependency_group=dependency_group)
 
     def bump_optional_dependencies(self):
         """Bump requirements in optional dependencies."""
@@ -591,7 +594,7 @@ class BumpMinimumDependencies:
         for category in self.optional_categories_to_update:
             requirements = optionals[category]
             new_requirements = self.get_new_requirements(requirements)  # ty:ignore[invalid-argument-type]
-            self.run_uv_command(new_requirements, extras_category=category)
+            self.run_uv_commands(new_requirements, extras_category=category)
 
     def run(self):
         """Perform all the requested and necessary updates."""

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -109,10 +109,10 @@ class BumpPackage:
         # prioritize bumping the micro/patch version number rather than
         # the minor version number, which is inconsistent with the
         # versioning practices assumed by bump-minimum-dependencies.
-        if len(epoch_major_minor_to_set_of_micro) <= 6:
+        if len(epoch_major_minor_to_set_of_micro) <= 5:
             for x in epoch_major_minor_to_set_of_micro:
                 number_of_micros = len(epoch_major_minor_to_set_of_micro[x])
-                if number_of_micros >= 15:
+                if number_of_micros >= 25:
                     major_minor = f"{x[1]}.{x[2]}"
                     first_patch = (
                         f"{major_minor}.{min(epoch_major_minor_to_set_of_micro[x])}"
@@ -121,11 +121,11 @@ class BumpPackage:
                         f"{major_minor}.{max(epoch_major_minor_to_set_of_micro[x])}"
                     )
                     logger.warning(
-                        f"{self.name} has {number_of_micros} releases between "
-                        f"{first_patch} and {last_patch}, suggesting a versioning "
-                        f"practice of bumping micro rather than minor release "
-                        f"numbers, and that it may be worthwhile to adjust the "
-                        f"minimum allowed version of {self.name} manually."
+                        f"{self.name} has {number_of_micros} identified releases "
+                        f"between {first_patch} and {last_patch}, suggesting a "
+                        f"versioning practice of bumping micro rather than minor "
+                        f"release numbers. Consider adjusting "
+                        f"the minimum allowed version of {self.name} manually."
                     )
 
         return epoch_major_minor_to_set_of_micro

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -9,7 +9,6 @@ __all__ = [
 
 import pathlib
 
-import click
 import requests
 
 from dep_logic.specifiers import parse_version_specifier
@@ -19,6 +18,7 @@ import datetime
 import packaging.specifiers
 import packaging.version
 import packaging.requirements
+from packaging.requirements import InvalidRequirement
 
 from packaging.requirements import Requirement
 
@@ -402,9 +402,13 @@ class BumpMinimumDependencies:
 
         try:
             all_requirements = self.pyproject.core_requirements
-        except (TypeError, AttributeError, KeyError) as exc:
-            errmsg = f"Unable to access dependencies in {self.pyproject_file!r}"
-            raise click.ClickException(errmsg) from exc
+        except (TypeError, AttributeError, KeyError):
+            msg = (
+                f"project.dependencies not found in "
+                f"{self.pyproject_file!r}; no updates to core project"
+                f"dependencies made."
+            )
+            logger.warning(msg)
 
         core_requirements_to_update: set[Requirement] = set()
         for requirement in all_requirements:

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -385,9 +385,6 @@ class BumpMinimumDependencies:
         if self.project_name:
             self.packages_to_skip.append(self.project_name)
 
-        if not self.pyproject.project:
-            raise RuntimeError("project table not defined")
-
         logger.info(f"Bumping minimum dependencies for {pyproject_file}")
 
     @property

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -423,7 +423,7 @@ class BumpMinimumDependencies:
                 and requirement.name not in self.only_update_these_packages
             ):
                 continue
-            core_requirements_to_update.append(requirement)
+            core_requirements_to_update.add(requirement)
 
         return core_requirements_to_update
 
@@ -456,7 +456,7 @@ class BumpMinimumDependencies:
 
     def get_new_requirements(
         self,
-        requirements: list[Requirement],
+        requirements: set[Requirement],
     ) -> list[str]:
         requirements_to_update: list[Requirement] = []
         for requirement in requirements:

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -41,6 +41,7 @@ logger = logging.getLogger("bump")
 logger.propagate = True
 logger.setLevel(logging.WARNING)
 
+
 class NoReleasesError(Exception):
     """When no releases of a package can be identified."""
 
@@ -252,7 +253,9 @@ def combine_requirements(
     combined = parsed_original & parsed_new
     new_specifier = str(original) if combined.is_empty() else str(combined)
     if "||" in new_specifier:
-        logger.warning("Cannot update versions with != in supported range; skipping.")
+        logger.warning(
+            "Cannot update versions with multiple != in supported range; skipping."
+        )
         return None
 
     new_specifier = utils.normalize_requirement_string(new_specifier)
@@ -512,20 +515,21 @@ class BumpMinimumDependencies:
                     cooldown_months=self.cooldown_months,
                 )
             except NoReleasesError:
-                logger.warning(f"[{requirement.name}] No releases identified "
-                               "from PyPI; skipping.")
+                logger.warning(
+                    f"[{requirement.name}] No releases identified from PyPI; skipping."
+                )
             except requests.exceptions.JSONDecodeError:
                 logger.warning(
-                    f"[{requirement.name}] Cannot access metadata from "
+                    f"[{requirement.name}] Cannot decode JSON metadata from "
                     f"PyPI; skipping.",
                 )
             # Catch all other exceptions since if a package cannot be updated
             # for whatever reason, it should be skipped with a warning issued.
-            except Exception:
+            except Exception as exc_info:
                 warning_message = (
-                    f"[{requirement.name}] Unable to update requirement. Skipping."
+                    f"[{requirement.name}] Unable to update requirement. Skipping.",
                 )
-                logger.warning(warning_message)
+                logger.warning(warning_message, exc_info=exc_info)
             else:
                 if not new_requirement:
                     continue
@@ -577,9 +581,22 @@ class BumpMinimumDependencies:
                 new_requirement,
             ]
 
-            msg = f"Running: {' '.join(command)}"
+            command_string = " ".join(command)
+
+            msg = f"Running: {command_string}"
             logger.info(msg)
-            subprocess.run(command)
+
+            try:
+                result = subprocess.run(
+                    command,
+                    check=True,
+                    capture_output=True,
+                )
+            except subprocess.CalledProcessError as exc_info:
+                logger.error(
+                    f"Command failed: {command_string}",
+                    exc_info=exc_info,
+                )
 
     def bump_core_requirements(self) -> None:
         """Bump the core package requirements."""

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -72,7 +72,6 @@ class BumpPackage:
     def released_versions(self) -> list[packaging.version.Version]:
         """The versions of all releases."""
         versions = sorted(self.versions_to_release_dates)
-        logger.debug(f"Most recent release of {self.name}: {versions[-1]}")
         return versions
 
     @functools.cached_property
@@ -146,8 +145,8 @@ class BumpPackage:
                 minor_releases.append(version)
             else:
                 logger.debug(
-                    f"{self.name} reconstructed version {version} not found "
-                    f"in released versions. Skipping."
+                    f"Reconstructed version {version} not found "
+                    f"in released versions. Skipping. [{self.name}]"
                 )
 
         return sorted(minor_releases)
@@ -182,9 +181,6 @@ class BumpPackage:
         drop_date: datetime.date = self.today - support_window
         cooldown_date: datetime.date = self.today - cooldown_period
 
-        logger.debug(f"{cooldown_date = !r}")
-        logger.debug(f"{drop_date = }")
-
         supported_releases_before_cooldown: list[packaging.version.Version] = []
         releases_before_drop_date: list[packaging.version.Version] = []
 
@@ -192,11 +188,11 @@ class BumpPackage:
             try:
                 release_date: datetime.date = self.versions_to_release_dates[release]
             except KeyError:
-                logger.info(
-                    f"Version {str(release)} of {self.name}  is not in the "
+                logger.debug(
+                    f"Version {str(release)} is not in the "
                     f"mapping from versions to release dates, possibly due "
                     f"to non-standard versioning or that the release was "
-                    f"yanked or a prerelease. Continuing."
+                    f"yanked or a prerelease. Continuing. [{self.name}]"
                 )
                 continue
 
@@ -206,8 +202,7 @@ class BumpPackage:
                 releases_before_drop_date.append(release)
 
         if not supported_releases_before_cooldown:
-            logger.debug(
-                f"No supported releases before cooldown. [{self.name}]")
+            logger.debug(f"No supported releases before cooldown. [{self.name}]")
 
         if not releases_before_drop_date:
             logger.debug(f"No releases before drop date. [{self.name}]")
@@ -275,6 +270,7 @@ def get_new_requirement_for_package(
     cooldown_months: float | int,
 ) -> str | None:
     """Combine the time-based requirement with the original requirement."""
+    logger.debug(f"Getting new requirement for {requirement.name}")
     package = BumpPackage(requirement.name)
     logger.debug(f"Pre-existing requirement: {str(requirement)}")
     calculated_minimum_version = package.oldest_supported_minor_release(
@@ -282,7 +278,7 @@ def get_new_requirement_for_package(
         cooldown_months=cooldown_months,
     )
     time_based_requirement = f">={calculated_minimum_version}"
-    logger.debug(f"Time-based requirement: {time_based_requirement}")
+    logger.debug(f"Time-based requirement: {requirement.name}{time_based_requirement}")
     combined_requirement = combine_requirements(
         original=requirement.specifier,
         new=time_based_requirement,

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -464,11 +464,13 @@ class BumpMinimumDependencies:
                 logger.warning(f"{requirement = } is not a Requirement")
             if requirement.name.lower() in self.packages_to_skip:
                 continue
+
             if (
                 self.only_update_these_packages
                 and requirement.name.lower() not in self.only_update_these_packages
             ):
                 continue
+
             requirements_to_update.append(requirement)
 
         logger.debug(

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -562,9 +562,8 @@ class BumpMinimumDependencies:
 
     def bump_dependency_groups(self):
         """Bump requirements in dependency groups."""
-        if not self.update_all_dependency_groups and not self.dependency_groups:
-            return
-
+        # if not self.update_all_dependency_groups and not self.dependency_groups:
+        #     return
         for dependency_group in self.dependency_groups_to_update:
             requirements = self.pyproject.dependency_groups[dependency_group]  # ty:ignore[not-subscriptable]
             new_requirements = self.get_new_requirements(requirements)  # ty:ignore[invalid-argument-type]
@@ -572,9 +571,8 @@ class BumpMinimumDependencies:
 
     def bump_optional_dependencies(self):
         """Bump requirements in optional dependencies."""
-        if not self.update_all_optionals and not self.optional_categories_to_update:
-            return
-
+        # if not self.update_all_optionals and not self.optional_categories_to_update:
+        #     return
         for category in self.optional_categories_to_update:
             requirements = self.pyproject.optional_dependencies[category]
             new_requirements = self.get_new_requirements(requirements)  # ty:ignore[invalid-argument-type]

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -41,6 +41,9 @@ logger = logging.getLogger("bump")
 logger.propagate = True
 logger.setLevel(logging.WARNING)
 
+class NoReleasesError(Exception):
+    """When no releases of a package can be identified."""
+
 
 class BumpPackage:
     """
@@ -171,6 +174,10 @@ class BumpPackage:
             releases.  If possible, the oldest supported minor release
             will be at least `cooldown_months` old.
         """
+
+        if not self.minor_releases:
+            msg = f"No releases identified for {self.name}."
+            raise NoReleasesError(msg)
 
         support_window = datetime.timedelta(
             days=math.ceil(drop_months * DAYS_PER_MONTH)
@@ -504,7 +511,9 @@ class BumpMinimumDependencies:
                     drop_months=self.drop_months,
                     cooldown_months=self.cooldown_months,
                 )
-
+            except NoReleasesError:
+                logger.warning(f"[{requirement.name}] No releases identified "
+                               "from PyPI; skipping.")
             except requests.exceptions.JSONDecodeError:
                 logger.warning(
                     f"Unable to access release metadata for {requirement} from"

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -562,20 +562,16 @@ class BumpMinimumDependencies:
 
     def bump_dependency_groups(self):
         """Bump requirements in dependency groups."""
-        # if not self.update_all_dependency_groups and not self.dependency_groups:
-        #     return
         for dependency_group in self.dependency_groups_to_update:
-            requirements = self.pyproject.dependency_groups[dependency_group]  # ty:ignore[not-subscriptable]
-            new_requirements = self.get_new_requirements(requirements)  # ty:ignore[invalid-argument-type]
+            requirements = self.pyproject.dependency_groups[dependency_group]
+            new_requirements = self.get_new_requirements(requirements)
             self.run_uv_commands(new_requirements, dependency_group=dependency_group)
 
     def bump_optional_dependencies(self):
         """Bump requirements in optional dependencies."""
-        # if not self.update_all_optionals and not self.optional_categories_to_update:
-        #     return
         for category in self.optional_categories_to_update:
             requirements = self.pyproject.optional_dependencies[category]
-            new_requirements = self.get_new_requirements(requirements)  # ty:ignore[invalid-argument-type]
+            new_requirements = self.get_new_requirements(requirements)
             self.run_uv_commands(new_requirements, extras_category=category)
 
     def run(self):

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -9,6 +9,7 @@ __all__ = [
 
 import pathlib
 
+import click
 import requests
 
 from dep_logic.specifiers import parse_version_specifier
@@ -378,8 +379,8 @@ class BumpMinimumDependencies:
         try:
             self.pyproject: PyProject = PyProject(pyproject_file)
         except FileNotFoundError as exc:
-            msg = f"Unable to load {pyproject_file}."
-            raise FileNotFoundError(msg) from exc
+            msg = f"Unable to load {pyproject_file}. Stopping."
+            raise click.ClickException(msg) from exc
 
         if self.project_name:
             self.packages_to_skip.append(self.project_name)

--- a/tests/data/base_case/pyproject.expected.toml
+++ b/tests/data/base_case/pyproject.expected.toml
@@ -11,6 +11,7 @@ dependencies = [
   "astropy>=6",
   "docutils>=0.20,<2",
   "heliopy>=1,<2",
+  "nose~=1.0.0",
   "nox>=2025.10.16",
   "numpy>=1.26",
   "plasmapy>=2024.2",

--- a/tests/data/base_case/pyproject.toml
+++ b/tests/data/base_case/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "astropy",
   "docutils!=0.19,<2",
   "heliopy<2",
+  "nose~=1.0.0",
   "nox>=2025.10.16",
   "numpy>=1.22.4",
   "plasmapy>=0.3.1",

--- a/tests/data/no_project_table/pyproject.expected.toml
+++ b/tests/data/no_project_table/pyproject.expected.toml
@@ -1,0 +1,4 @@
+[dependency-groups]
+group = [
+    "numpy",
+]

--- a/tests/data/no_project_table/pyproject.expected.toml
+++ b/tests/data/no_project_table/pyproject.expected.toml
@@ -1,4 +1,4 @@
 [dependency-groups]
 group = [
-    "numpy",
+    "numpy>=2.1",
 ]

--- a/tests/data/no_project_table/pyproject.toml
+++ b/tests/data/no_project_table/pyproject.toml
@@ -1,0 +1,4 @@
+[dependency-groups]
+group = [
+    "numpy",
+]

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -48,6 +48,7 @@ def get_errmsg_from_file_comparison(
 @pytest.mark.parametrize(
     "subdir,date,kwargs",
     [
+        ("base_case", "2026-01-01", {"drop_months": 24, "cooldown_months": 21}),
         (
                 "no_project_table",
                 "2026-08-18",
@@ -81,7 +82,6 @@ def get_errmsg_from_file_comparison(
                 "all_extras": True,
             },
         ),
-        ("base_case", "2026-01-01", {"drop_months": 24, "cooldown_months": 21}),
         (
             "bump_all_dependency_groups",
             "2026-01-01",

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -6,7 +6,7 @@ import pytest
 import logging
 from pathlib import Path
 
-bump.logger.setLevel(logging.INFO)
+bump.logger.setLevel(logging.DEBUG)
 
 
 def get_errmsg_from_file_comparison(

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -49,6 +49,13 @@ def get_errmsg_from_file_comparison(
     "subdir,date,kwargs",
     [
         (
+                "no_project_table",
+                "2026-08-18",
+                {
+
+                },
+        ),
+        (
             "bump_pyright",
             "2026-08-18",
             {

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -50,11 +50,11 @@ def get_errmsg_from_file_comparison(
     [
         ("base_case", "2026-01-01", {"drop_months": 24, "cooldown_months": 21}),
         (
-                "no_project_table",
-                "2026-08-18",
-                {
-
-                },
+            "no_project_table",
+            "2026-08-18",
+            {
+                "group": ["group"],
+            },
         ),
         (
             "bump_pyright",

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -22,9 +22,6 @@ def test_core_requirements(simple_pyproject: PyProject):
 
 def test_optionals(simple_pyproject: PyProject):
     expected = {"optional": {Requirement("sunpy")}}
-    print(simple_pyproject.optional_dependencies)
-    print(expected)
-
     assert simple_pyproject.optional_dependencies == expected
 
 


### PR DESCRIPTION
 - Run `uv add` separately for each update so that if one update fails, then the others will still proceed.
 - Let tool proceed even when there does not exist a `project.dependencies` table.
 - Removed some example `pyproject.toml` cases that don't define dependencies
 - Added a `NoReleasesError` to allow exception handling for when no releases of a package are identified.
 - Adjusted logger messages and settings.
 - Raised `ClickException` instead of FileNotFoundError.
 - Updated type hints after #31.

> [!NOTE]
> Some of the work on having cleaner exception handling was inspired by the `pyproject.toml` file from `sqlalchemy`, which has a TOML read error when interacting with `uv add`.  Turns out that it's an issue between `sqlalchemy` and `uv add`, rather than with `bump-minimum-dependencies`.  