### PR TITLE
Drop `pyproject-parser` dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,14 @@ ci:  # https://pre-commit.ci/#configuration
 
 repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.14.2
+  hooks:
+  - id: ruff-check
+    name: ruff-check (see https://docs.astral.sh/ruff/rules)
+    args: [--fix]
+  - id: ruff-format
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
   hooks:
@@ -73,14 +81,6 @@ repos:  # https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
   - id: typos
     name: typos (add false positives to _typos.toml)
     exclude: tests/data
-
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.2
-  hooks:
-  - id: ruff-check
-    name: ruff-check (see https://docs.astral.sh/ruff/rules)
-    args: [--fix]
-  - id: ruff-format
 
 - repo: https://github.com/abravalheri/validate-pyproject
   rev: v0.24.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "charset-normalizer==3.3.2",
   "click>=8.4.2,<9",
   "dep-logic>=0.7.1",
-  "pyproject-parser~=0.14",
   "requests>=2.34.2",
   # older version of uv shift positions of certain inline comments
   "uv>=0.12.5",

--- a/src/bump_minimum_dependencies/__init__.py
+++ b/src/bump_minimum_dependencies/__init__.py
@@ -1,5 +1,6 @@
-__all__ = ["bump", "main", "utils"]
+__all__ = ["bump", "main", "pyproject", "utils"]
 
 from . import bump
 from . import utils
 from . import main
+from . import pyproject

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -22,8 +22,8 @@ import packaging.requirements
 
 from packaging.requirements import Requirement
 
-from pyproject_parser import PyProject
 
+from bump_minimum_dependencies.pyproject import PyProject
 from . import utils
 
 import logging
@@ -376,29 +376,23 @@ class BumpMinimumDependencies:
         ]
 
         try:
-            self.pyproject: PyProject = PyProject.load(pyproject_file)
+            self.pyproject: PyProject = PyProject(pyproject_file)
         except FileNotFoundError as exc:
-            exception_message = str(exc).lower()
-            msg = f"Unable to load {pyproject_file} with pyproject_parser.PyProject.load()."
-            if "readme" in exception_message or "license" in exception_message:
-                msg += (
-                    " If a readme or license file is declared in a pyproject.toml, "
-                    "these files must be present alongside pyproject.toml."
-                )
+            msg = f"Unable to load {pyproject_file}."
             raise FileNotFoundError(msg) from exc
 
-        if isinstance(self.project_name, str):
+        if self.project_name:
             self.packages_to_skip.append(self.project_name)
 
         if not self.pyproject.project:
             raise RuntimeError("project table not defined")
 
-        logger.info(f"Bumping minimum dependencies for {self.pyproject_file}")
+        logger.info(f"Bumping minimum dependencies for {pyproject_file}")
 
     @property
     def project_name(self) -> str | None:
         """The name of the project, if available."""
-        return self.pyproject.project.get("name", None)  # ty: ignore[unresolved-attribute]
+        return self.pyproject.project_name
 
     @property
     def core_requirements_to_update(self) -> list[Requirement]:
@@ -407,7 +401,7 @@ class BumpMinimumDependencies:
             return []
 
         try:
-            all_requirements = self.pyproject.project["dependencies"]  # ty:ignore[not-subscriptable]
+            all_requirements = self.pyproject.core_requirements
         except (TypeError, AttributeError, KeyError) as exc:
             errmsg = f"Unable to access dependencies in {self.pyproject_file!r}"
             raise click.ClickException(errmsg) from exc

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -456,11 +456,8 @@ class BumpMinimumDependencies:
     ) -> list[str]:
         requirements_to_update: list[Requirement] = []
         for requirement in requirements:
-            if isinstance(requirement, str):
-                requirement = utils.normalize_requirement_string(requirement)
-                requirement = Requirement(requirement)
             if not isinstance(requirement, Requirement):
-                continue
+                logger.warning(f"{requirement = } is not a Requirement")
             if requirement.name.lower() in self.packages_to_skip:
                 continue
             if (

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -429,7 +429,7 @@ class BumpMinimumDependencies:
         if not self.pyproject.dependency_groups:
             return []
 
-        all_dependency_groups: list[str] = sorted(self.pyproject.dependency_groups)
+        all_dependency_groups: list[str] = sorted(self.pyproject.dependency_group_names)
 
         if undefined := set(self.dependency_groups) - set(all_dependency_groups):
             msg = f"the following dependency groups are not defined: {undefined}"
@@ -442,9 +442,7 @@ class BumpMinimumDependencies:
     @property
     def optional_categories_to_update(self) -> list[str]:
         """Names of categories of optional dependencies to be updated if necessary."""
-        all_optionals: list[str] = sorted(
-            self.pyproject.project.get("optional-dependencies", [])  # ty: ignore[unresolved-attribute]
-        )
+        all_optionals: list[str] = self.pyproject.optional_category_names
         if undefined := set(self.optional_categories) - set(all_optionals):
             raise ValueError(
                 f"the following optional dependency categories are not "
@@ -568,7 +566,7 @@ class BumpMinimumDependencies:
             return
 
         for dependency_group in self.dependency_groups_to_update:
-            requirements = self.pyproject.dependency_groups[dependency_group]  # ty:ignore[not-subscriptable]
+            requirements = self.pyproject.dependency_groups[dependency_group]
             new_requirements = self.get_new_requirements(requirements)  # ty:ignore[invalid-argument-type]
             self.run_uv_command(new_requirements, dependency_group=dependency_group)
 
@@ -577,7 +575,7 @@ class BumpMinimumDependencies:
         if not self.update_all_optionals and not self.optional_categories_to_update:
             return
 
-        optionals = self.pyproject.project.get("optional-dependencies")  # ty:ignore[unresolved-attribute]
+        optionals = self.pyproject.optional_dependencies
         if not optionals:
             logger.info("No optional dependencies found.")
             return

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -192,7 +192,7 @@ class BumpPackage:
             try:
                 release_date: datetime.date = self.versions_to_release_dates[release]
             except KeyError:
-                logger.debug(
+                logger.info(
                     f"{self.name} {str(release)} is not in the "
                     f"mapping from versions to release dates, possibly due "
                     f"to non-standard versioning or that the release was "
@@ -275,7 +275,7 @@ def get_new_requirement_for_package(
 ) -> str | None:
     """Combine the time-based requirement with the original requirement."""
     package = BumpPackage(requirement.name)
-    logger.info(f"Pre-existing requirement: {str(requirement)}")
+    logger.debug(f"Pre-existing requirement: {str(requirement)}")
     calculated_minimum_version = package.oldest_supported_minor_release(
         drop_months=drop_months,
         cooldown_months=cooldown_months,

--- a/src/bump_minimum_dependencies/pyproject.py
+++ b/src/bump_minimum_dependencies/pyproject.py
@@ -1,0 +1,78 @@
+"""Contains a class to access requirement information in pyproject.toml."""
+
+__all__ = ["PyProject"]
+
+
+from pathlib import Path
+import tomllib
+import functools
+import contextlib
+from packaging.requirements import Requirement, InvalidRequirement
+from typing import Any
+
+
+class PyProject:
+    """A class to access requirements information in pyproject.toml."""
+
+    def __init__(self, pyproject_file: Path | str):
+        self.pyproject_file = Path(pyproject_file)
+
+        with open(self.pyproject_file, "rb") as f:
+            self.pyproject = tomllib.load(f)
+
+    @property
+    def project(self) -> dict[str, Any]:
+        """The project table in pyproject.toml."""
+        return self.pyproject.get("project", {})
+
+    @property
+    def project_name(self) -> str | None:
+        """Get project.name from pyproject.toml."""
+        return self.project.get("name", None)
+
+    @functools.cached_property
+    def core_requirements(self) -> set[Requirement]:
+        """
+        Get project.dependencies from pyproject.toml, converting them
+        into `packaging.requirements.Requirement` objects.
+        """
+        core_requirements = set()
+        for requirement in self.project.get("dependencies", set()):
+            with contextlib.suppress(InvalidRequirement):
+                core_requirements.add(Requirement(requirement))
+        return core_requirements
+
+    @functools.cached_property
+    def optional_dependencies(self) -> dict[str, set[Requirement]]:
+        """
+        Get project.optional-dependencies from pyproject.toml, converting
+        them into `packaging.requirements.Requirement` objects.
+        """
+        optional_dependencies: dict[str, set[Requirement]] = {}
+        original_extras = self.project.get("optional-dependencies", {})
+        for extra in original_extras:
+            optional_dependencies[extra] = set()
+            for dependency in original_extras[extra]:
+                with contextlib.suppress(InvalidRequirement):
+                    optional_dependencies[extra].add(
+                        Requirement(dependency),
+                    )
+        return optional_dependencies
+
+    @functools.cached_property
+    def dependency_groups(self) -> dict[str, set[Requirement]]:
+        """
+        Get dependency-groups from pyproject.toml, converting them into
+        `packaging.requirements.Requirement` objects.
+        """
+        dependency_groups: dict[str, set[Requirement]] = {}
+        original_groups: dict[str, list[str]] = self.pyproject.get(
+            "dependency-groups", {}
+        )
+        for group in original_groups:
+            dependency_groups[group] = set()
+            for dependency in original_groups[group]:
+                with contextlib.suppress(InvalidRequirement):
+                    dependency_groups[group].add(Requirement(dependency))
+
+        return dependency_groups

--- a/src/bump_minimum_dependencies/pyproject.py
+++ b/src/bump_minimum_dependencies/pyproject.py
@@ -38,7 +38,7 @@ class PyProject:
         """
         core_requirements = set()
         for requirement in self.project.get("dependencies", set()):
-            with contextlib.suppress(InvalidRequirement):
+            with contextlib.suppress(InvalidRequirement, TypeError):
                 core_requirements.add(Requirement(requirement))
         return core_requirements
 
@@ -53,11 +53,21 @@ class PyProject:
         for extra in original_extras:
             optional_dependencies[extra] = set()
             for dependency in original_extras[extra]:
-                with contextlib.suppress(InvalidRequirement):
+                with contextlib.suppress(InvalidRequirement, TypeError):
                     optional_dependencies[extra].add(
                         Requirement(dependency),
                     )
         return optional_dependencies
+
+    @functools.cached_property
+    def optional_category_names(self) -> list[str]:
+        """The category names for optional dependencies."""
+        return sorted(self.optional_dependencies.keys())
+
+    @functools.cached_property
+    def dependency_group_names(self) -> list[str]:
+        """The names of dependency groups."""
+        return sorted(self.dependency_groups.keys())
 
     @functools.cached_property
     def dependency_groups(self) -> dict[str, set[Requirement]]:
@@ -72,7 +82,7 @@ class PyProject:
         for group in original_groups:
             dependency_groups[group] = set()
             for dependency in original_groups[group]:
-                with contextlib.suppress(InvalidRequirement):
+                with contextlib.suppress(InvalidRequirement, TypeError):
                     dependency_groups[group].add(Requirement(dependency))
 
         return dependency_groups

--- a/tests/data/astropy3/pyproject.expected.toml
+++ b/tests/data/astropy3/pyproject.expected.toml
@@ -138,7 +138,7 @@ typing = [
 ]
 docs = [
     "astropy[recommended]",  # installs the [recommended] dependencies
-    "sphinx>=8.2.0,<9",  # keep in sync with docs/conf.py
+    "sphinx>=9",  # keep in sync with docs/conf.py
     "sphinx-astropy[confv3]>=1.11",
     "pytest>=8.0.0",
     "sphinx-changelog>=1.4.0",

--- a/tests/data/astropy3/pyproject.toml
+++ b/tests/data/astropy3/pyproject.toml
@@ -138,7 +138,7 @@ typing = [
 ]
 docs = [
     "astropy[recommended]",  # installs the [recommended] dependencies
-    "sphinx>=8.2.0,<9",  # keep in sync with docs/conf.py
+    "sphinx>=9",  # keep in sync with docs/conf.py
     "sphinx-astropy[confv3]>=1.11",
     "pytest>=8.0.0",
     "sphinx-changelog>=1.4.0",

--- a/tests/data/simple_pyproject/pyproject.toml
+++ b/tests/data/simple_pyproject/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "simple-pyproject"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+    "numpy>=2",
+]
+
+[project.optional-dependencies]
+optional = [
+    "sunpy",
+]
+
+[dependency-groups]
+group = [
+    "plasmapy>=0.8.1",
+]

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -163,7 +163,9 @@ def get_errmsg_from_file_comparison(
         ),
     ],
 )
-def test_pyproject(tmp_path, monkeypatch, freezer, subdir, kwargs, date) -> None:
+def test_bumping_minimum_requirements(
+    tmp_path, monkeypatch, freezer, subdir, kwargs, date
+) -> None:
     freezer.move_to(date)
 
     data_dir: Path = Path(__file__).parent / "data" / subdir
@@ -196,7 +198,7 @@ def test_pyproject(tmp_path, monkeypatch, freezer, subdir, kwargs, date) -> None
         ("pyproject-fmt", 100, 100, "0.1"),
     ],
 )
-def test_bump(
+def test_bumping_single_package(
     name: str, drop_months: int, cooldown_months: int, expected: str, freezer
 ) -> None:
     freezer.move_to("2026-01-01")

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,0 +1,33 @@
+import pytest
+from pathlib import Path
+from packaging.requirements import Requirement
+
+from bump_minimum_dependencies.pyproject import PyProject
+
+
+@pytest.fixture()
+def simple_pyproject() -> PyProject:
+    data_dir = Path(__file__).parent / "data"
+    pyproject_file = data_dir / "simple_pyproject" / "pyproject.toml"
+    return PyProject(pyproject_file)
+
+
+def test_project_name(simple_pyproject: PyProject):
+    assert simple_pyproject.project_name == "simple-pyproject"
+
+
+def test_core_requirements(simple_pyproject: PyProject):
+    assert simple_pyproject.core_requirements == {Requirement("numpy>=2")}
+
+
+def test_optionals(simple_pyproject: PyProject):
+    expected = {"optional": {Requirement("sunpy")}}
+    print(simple_pyproject.optional_dependencies)
+    print(expected)
+
+    assert simple_pyproject.optional_dependencies == expected
+
+
+def test_groups(simple_pyproject: PyProject):
+    expected = {"group": {Requirement("plasmapy>=0.8.1")}}
+    assert simple_pyproject.dependency_groups == expected

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -31,3 +31,11 @@ def test_optionals(simple_pyproject: PyProject):
 def test_groups(simple_pyproject: PyProject):
     expected = {"group": {Requirement("plasmapy>=0.8.1")}}
     assert simple_pyproject.dependency_groups == expected
+
+
+def test_dependency_group_names(simple_pyproject: PyProject):
+    assert simple_pyproject.dependency_group_names == ["group"]
+
+
+def test_optional_category_names(simple_pyproject: PyProject):
+    assert simple_pyproject.optional_category_names == ["optional"]

--- a/uv.lock
+++ b/uv.lock
@@ -7,19 +7,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "apeye-core"
-version = "1.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "domdf-python-tools" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/4c/4f108cfd06923bd897bf992a6ecb6fb122646ee7af94d7f9a64abd071d4c/apeye_core-1.1.5.tar.gz", hash = "sha256:5de72ed3d00cc9b20fea55e54b7ab8f5ef8500eb33a5368bc162a5585e238a55", size = 96511, upload-time = "2024-01-30T17:45:48.727Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/9f/fa9971d2a0c6fef64c87ba362a493a4f230eff4ea8dfb9f4c7cbdf71892e/apeye_core-1.1.5-py3-none-any.whl", hash = "sha256:dc27a93f8c9e246b3b238c5ea51edf6115ab2618ef029b9f2d9a190ec8228fbf", size = 99286, upload-time = "2024-01-30T17:45:46.764Z" },
-]
-
-[[package]]
 name = "argcomplete"
 version = "3.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -38,15 +25,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boolean-py"
-version = "5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
-]
-
-[[package]]
 name = "bump-minimum-dependencies"
 version = "0.3.0"
 source = { editable = "." }
@@ -54,7 +32,6 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "click" },
     { name = "dep-logic" },
-    { name = "pyproject-parser" },
     { name = "requests" },
     { name = "uv" },
 ]
@@ -78,7 +55,6 @@ requires-dist = [
     { name = "charset-normalizer", specifier = "==3.3.2" },
     { name = "click", specifier = ">=8.4.2,<9" },
     { name = "dep-logic", specifier = ">=0.7.1" },
-    { name = "pyproject-parser", specifier = "~=0.14" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "uv", specifier = ">=0.12.5" },
 ]
@@ -92,7 +68,7 @@ dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-freezer", specifier = "==0.4.9" },
     { name = "python-dateutil", specifier = "==2.8.2" },
-    { name = "rich", specifier = ">=15.0.0" },
+    { name = "rich", specifier = ">=15" },
     { name = "tomli-w", specifier = ">=1.2" },
     { name = "ty", specifier = ">=0.0.69" },
 ]
@@ -173,51 +149,12 @@ wheels = [
 ]
 
 [[package]]
-name = "dist-meta"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "domdf-python-tools" },
-    { name = "handy-archives" },
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/b6/fb5d09760948c0292321aa292dd658fb6f17e9d9daca8064a060249aa543/dist_meta-0.9.0.tar.gz", hash = "sha256:fa16ebd5574744a09596ab342083a11d7209d8d05cf32891d1c985be7ec0cbd7", size = 18713, upload-time = "2025-02-12T17:04:52.611Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/59/74d2029a2c7b6bcdf065c53f7aa2c5c0d3f7959c3fe2e07cf7b07a25c8eb/dist_meta-0.9.0-py3-none-any.whl", hash = "sha256:1d38a7f5e83ab2fc5e1fb9af92d995ec27718377d000c7318367db85a2ba07db", size = 27595, upload-time = "2025-02-12T17:04:51.464Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/8d/873e9252ea2c0e0c857884e0a2899ec43ade132345df1925ef24cbe64f18/distlib-0.4.2.tar.gz", hash = "sha256:baeb401c90f27acd15c4861ae0847d1e731c27ac3dbf4210643ba61fa1e813db", size = 614914, upload-time = "2026-06-08T16:24:15.439Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/aa891c893821d4d127292ed66c6940d1d715894bd5a0ce048056bc641773/distlib-0.4.2-py2.py3-none-any.whl", hash = "sha256:ca4cb11e5d746b5ec13c199cbf19ae27a241f89702b54e153a74332955446067", size = 470510, upload-time = "2026-06-08T16:24:13.208Z" },
-]
-
-[[package]]
-name = "dom-toml"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "domdf-python-tools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/91/cdad3f64c5bbe7650fc617f2f756b28827dd5f30b9f7b78597ce3e96fcd2/dom_toml-2.3.0.tar.gz", hash = "sha256:04d1138a7588119ec37ffe59e6474739a7ce7fcfcdf76555a064878ad82e3ae0", size = 13041, upload-time = "2026-01-22T23:12:06.225Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/cb/20465053f0f4854c261c038afce2703d71cc71d58035a53404128b1abfe7/dom_toml-2.3.0-py3-none-any.whl", hash = "sha256:bc2f985db6964de47b113783a6b18f1688693b2a47dec3c7451d3531ccab7029", size = 17505, upload-time = "2026-01-22T23:12:05.328Z" },
-]
-
-[[package]]
-name = "domdf-python-tools"
-version = "3.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "natsort" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/8b/ab2d8a292bba8fe3135cacc8bfd3576710a14b8f2d0a8cde19130d5c9d21/domdf_python_tools-3.10.0.tar.gz", hash = "sha256:2ae308d2f4f1e9145f5f4ba57f840fbfd1c2983ee26e4824347789649d3ae298", size = 100458, upload-time = "2025-02-12T17:34:05.747Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/11/208f72084084d3f6a2ed5ebfdfc846692c3f7ad6dce65e400194924f7eed/domdf_python_tools-3.10.0-py3-none-any.whl", hash = "sha256:5e71c1be71bbcc1f881d690c8984b60e64298ec256903b3147f068bc33090c36", size = 126860, upload-time = "2025-02-12T17:34:04.093Z" },
 ]
 
 [[package]]
@@ -239,15 +176,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
-]
-
-[[package]]
-name = "handy-archives"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/c1/de653344a7be2aea0c3123d0ad1ea55fa56ced0e6336f98d5542a64d28e9/handy_archives-0.2.0.tar.gz", hash = "sha256:fba21101fd9e29d5e3b72823261aaae06b9350686f0d2067786d64dce73eb3f6", size = 8863, upload-time = "2023-07-31T14:38:43.566Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/e5/23451e1cee169259fbc98d2b2ed7b1c3711b707355896c9c3761325ddb01/handy_archives-0.2.0-py3-none-any.whl", hash = "sha256:8495e08f3cd1c452fe65570db1869db07f709149f85c7e9cd8f3f461df436318", size = 8965, upload-time = "2023-07-31T14:38:42.448Z" },
 ]
 
 [[package]]
@@ -278,18 +206,6 @@ wheels = [
 ]
 
 [[package]]
-name = "license-expression"
-version = "30.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "boolean-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -308,15 +224,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "natsort"
-version = "8.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
 ]
 
 [[package]]
@@ -412,26 +319,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyproject-parser"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "apeye-core" },
-    { name = "attrs" },
-    { name = "dom-toml" },
-    { name = "domdf-python-tools" },
-    { name = "license-expression" },
-    { name = "natsort" },
-    { name = "packaging" },
-    { name = "shippinglabel" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/c9/349559ef168faded88c404997c494684e0b1a4aa8600b1af8f9f6c0ba590/pyproject_parser-0.14.0.tar.gz", hash = "sha256:4047bd9a25115e400199e672cd9d8f8ba405d8148d65a76cbf3afbcf77e966e2", size = 26631, upload-time = "2025-12-11T17:51:03.981Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/c8/adffda2d70ae4090dc709b991c0f1749bc6917ba5168a5364a5db728a07a/pyproject_parser-0.14.0-py3-none-any.whl", hash = "sha256:10adf69e48c2dcfb993f94b4981acfd7d0a201846bce17a67c9736f42505e790", size = 34890, upload-time = "2025-12-11T17:51:02.947Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -513,22 +400,6 @@ wheels = [
 ]
 
 [[package]]
-name = "shippinglabel"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dist-meta" },
-    { name = "dom-toml" },
-    { name = "domdf-python-tools" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/fc/6d6e3d96d05d67c9edd0978b34e914f128d098d6140ebc713a814441bada/shippinglabel-2.3.0.tar.gz", hash = "sha256:25c0c3194c011c0355dff8f56cc0b31688f693b209f5849d44991d8a2ec91f2f", size = 24754, upload-time = "2025-05-08T14:12:44.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/25/67b56716355bed5477be57fed54c9d4d7c81518011bc1fa79b35bbf85702/shippinglabel-2.3.0-py3-none-any.whl", hash = "sha256:37811ae077f4a40e524efa013a136e3e2d295a96ad149a4e84b7788dd7f3b64a", size = 29992, upload-time = "2025-05-08T14:12:43.304Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -569,15 +440,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/3e/eae485fd86c1585943fd4e1746b0757b2da01e2c43136ebe8c686fe1c7f1/ty-0.0.73-py3-none-win32.whl", hash = "sha256:03347a612f0fa020b19bfd8dbd521db6ecc75d377a3e4d4f6e6c2e62871da4cc", size = 12053187, upload-time = "2026-08-19T03:12:37.565Z" },
     { url = "https://files.pythonhosted.org/packages/a7/01/9b8b983786e3ce34924e372e8b76b92b508273ab65c589fc7e88cc03ee17/ty-0.0.73-py3-none-win_amd64.whl", hash = "sha256:cedd05122ded0b5dcc55431a370e974b747f99c41c290a3d2ab8c1867f197519", size = 12693838, upload-time = "2026-08-19T03:12:39.483Z" },
     { url = "https://files.pythonhosted.org/packages/ea/88/25333bbfea6a5dc064371d2002d3d4807db90b84d5448f9106b2712b0fbc/ty-0.0.73-py3-none-win_arm64.whl", hash = "sha256:e47068f8369dea5d641a26a2ad0a947a320b02ff87099b07e95de0323245a4dc", size = 12443573, upload-time = "2026-08-19T03:12:41.449Z" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A characteristic of `pyproject-parser` is that it can fail reading in a `pyproject.toml` file when the `pyproject.toml` has problems, or when the file declares readme and/or license files that are missing.  Since that could cause problems for end users of bump-minimum-dependencies, this PR switches over to an internal class for accessing solely the information needed by bump-minimum-dependencies.

Closes #28.