### PR TITLE
Add rich formatting to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ bump-minimum-dependencies --extra dev
 
 - This tool invokes `uv add --frozen` to update dependencies in `pyproject.toml` without updating lock files or syncing virtual environments.
 
-- Using [`dep-logic`](https://github.com/pdm-project/dep-logic) allows bump-minimum-dependencies to handle a wide variety of requirements specifiers and perform logical operations to combine multiple requirements specifiers. For example, `>=4.1,<5` and `>=4.2` will be combined into `>=4.2,<5`.
+- Using [`dep-logic`](https://github.com/pdm-project/dep-logic) allows bump-minimum-dependencies to handle a wide variety of requirements specifiers and perform logical operations to combine multiple requirements specifiers. For example, `>=4.1,<5` and `>=4.2` will be combined into `>=4.2,<5`. Some requirements might not be updated, such as those using `==` or `~=`.
 
 - If the time-based requirement is mutually exclusive with the original requirement, the original requirement will be preserved.
 
@@ -119,24 +119,15 @@ bump-minimum-dependencies --extra dev
 
 - Within a given category, dependencies with markers (such as `'setuptools; python_version > "3.11"'`) will not be updated.
 
-- Requirements may be normalized upon updates by `uv add`. Opinionated autoformatters like [pyproject-fmt](https://pyproject-fmt.readthedocs.io/en/latest/index.html) reduce the need for requirements normalization. Example normalizations include:
-
-  - `.0` suffixes may be removed, since `X.Y` and `X.Y.0` "are not considered distinct release numbers" as per [PEP 440](https://peps.python.org/pep-0440).
-  - Package names may be made lower case.
-  - Single quotes may be changed to double quotes.
+- Requirements may be normalized upon updates by `uv add` (e.g., removal of `.0` suffixes and making package names lower case).
 
 ## Limitations and caveats
 
-- This tool may be unable to update certain dependencies that:
+- This tool may be unable to update certain dependencies that use non-standard [version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers) or use `!=` multiple times.
 
-  - Use non-standard [version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers).
-  - Have resulting requirements with multiple `!=` operators (as of `dep-logic==0.7.1`).
-
-- This tool does not guarantee that an environment can be created that includes the minimum allowed versions of all direct dependencies, but this can be tested with `uv lock --resolution=lowest-direct --dry-run`.
+- This tool does not guarantee that an environment can be created that includes the minimum allowed versions of all direct dependencies, but this can be tested with `uv lock --resolution=lowest-direct --dry-run` and then manually fixed.
 
 - This tool does not update `build-system.requires`.
-
-- README and license files declared in `pyproject.toml` must be present so that `pyproject.toml` due to an upstream limitation with [pyproject-parser.PyProject.load()](https://pyproject-parser.readthedocs.io/en/latest/api/pyproject-parser.html#pyproject_parser.PyProject.load).
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -24,31 +24,34 @@ Usage: bump-minimum-dependencies [OPTIONS]
   warning.
 
 Options:
-  --pyproject-file FILE          Path to pyproject.toml. Default is
-                                 pyproject.toml in current directory.
-  --drop-months FLOAT RANGE      Drop minor releases older than this many
-                                 months ago. Defaults to 24.  [x>=0]
-  --cooldown-months FLOAT RANGE  Ensure that there is at least one release
-                                 this many months old, if possible. Defaults
-                                 to 12 or the value provided to --drop-months,
-                                 whichever is smaller.  [x>=0]
-  --only-package TEXT            Name of a package to update. May be provided
-                                 multiple times. When this option is used, all
-                                 other packages will be skipped.
-  --skip-package TEXT            Name of a package to skip when performing
-                                 updates. May be provided multiple times.
-  --extra TEXT                   Name of an optional dependencies category to
-                                 update. May be provided multiple times.
-  --all-extras                   If provided, all optional dependency
-                                 categories will be updated.
-  --group TEXT                   Name of a dependency group to update. May be
-                                 provided multiple times.
-  --all-groups                   If provided, all dependency groups will be
-                                 updated.
-  --skip-core                    If provided, core project dependencies will
-                                 not be updated.
-  --version                      Show the version and exit.
-  --help                         Show this message and exit.
+  --pyproject-file FILE           Path to pyproject.toml. Default is
+                                  pyproject.toml in current directory.
+  --drop-months FLOAT RANGE       Drop minor releases older than this many
+                                  months ago. Defaults to 24.  [x>=0]
+  --cooldown-months FLOAT RANGE   Ensure that there is at least one release
+                                  this many months old, if possible. Defaults
+                                  to 12 or the value provided to --drop-
+                                  months, whichever is smaller.  [x>=0]
+  --only-package TEXT             Name of a package to update. May be provided
+                                  multiple times. When this option is used,
+                                  all other packages will be skipped.
+  --skip-package TEXT             Name of a package to skip when performing
+                                  updates. May be provided multiple times.
+  --extra TEXT                    Name of an optional dependencies category to
+                                  update. May be provided multiple times.
+  --all-extras                    If provided, all optional dependency
+                                  categories will be updated.
+  --group TEXT                    Name of a dependency group to update. May be
+                                  provided multiple times.
+  --all-groups                    If provided, all dependency groups will be
+                                  updated.
+  --skip-core                     If provided, core project dependencies will
+                                  not be updated.
+  --verbosity [DEBUG|INFO|WARNING|ERROR|CRITICAL|NOTSET]
+                                  Logging verbosity level. Defaults to
+                                  WARNING.
+  --version                       Show the version and exit.
+  --help                          Show this message and exit.
 ```
 
 ## Examples

--- a/noxfile.py
+++ b/noxfile.py
@@ -352,7 +352,12 @@ def bump_pyproject(session: nox.Session, package: str) -> None:
     session.log(f"Project: {path.name}")
     shutil.copy2("pyproject.original.toml", "pyproject.toml")
 
-    session.run("bump-minimum-dependencies", "--all-groups", "--all-extras")
+    session.run(
+        "bump-minimum-dependencies",
+        "--all-groups",
+        "--all-extras",
+        *session.posargs,
+    )
 
     session.run(
         "diff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "dep-logic>=0.7.1",
   "requests>=2.34.2",
   # older version of uv shift positions of certain inline comments
+  "rich>=15.0.0",
   "uv>=0.12.5",
 ]
 urls.Source = "https://github.com/namurphy/bump-minimum-dependencies"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "dep-logic>=0.7.1",
   "requests>=2.34.2",
   # older version of uv shift positions of certain inline comments
-  "rich>=15.0.0",
+  "rich>=15",
   "uv>=0.12.5",
 ]
 urls.Source = "https://github.com/namurphy/bump-minimum-dependencies"

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -151,8 +151,8 @@ class BumpPackage:
 
     def oldest_supported_minor_release(
         self,
-        drop_months: float = 24,
-        cooldown_months: float = 18,
+        drop_months: float,
+        cooldown_months: float,
     ) -> str:
         """
         Get the oldest supported minor release of the package.

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -212,17 +212,25 @@ class BumpPackage:
             logger.debug(f"[{self.name}] First release is during the cooldown period.")
             return utils.normalize_requirement_string(min(self.released_versions))
 
-        minimum_allowed_requirement = utils.normalize_requirement_string(
-            min(
-                supported_releases_before_cooldown,
-                default=max(
-                    releases_before_drop_date,
-                    default=min(self.minor_releases),
-                ),
-            )
+        new_minimum_version = min(
+            supported_releases_before_cooldown,
+            default=max(
+                releases_before_drop_date,
+                default=min(self.minor_releases),
+            ),
         )
 
-        return minimum_allowed_requirement
+        release_date: datetime.date = self.versions_to_release_dates[
+            new_minimum_version
+        ]
+
+        logger.info(
+            f"[{self.name}] "
+            f"New minimum version: {str(new_minimum_version)} "
+            f"({release_date.isoformat()})."
+        )
+
+        return utils.normalize_requirement_string(new_minimum_version)
 
 
 def combine_requirements(

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -225,9 +225,10 @@ class BumpPackage:
         ]
 
         logger.info(
-            f"[{self.name}] "
+            f"[blue]({self.name.strip()})[/] "
             f"New minimum version: {str(new_minimum_version)} "
-            f"({release_date.isoformat()})."
+            f"({release_date.isoformat()}).",
+            extra={"markup": True},
         )
 
         return utils.normalize_requirement_string(new_minimum_version)

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -96,7 +96,6 @@ class BumpPackage:
                 if version.post is not None:
                     logger.info(
                         f"{package_prefix(self.name)} Skipping post release: {str(version)}",
-                        extra={"markup": True},
                     )
                     continue
                 epoch_major_minor_to_set_of_micro[(epoch, major, minor)] = {micro}
@@ -124,7 +123,6 @@ class BumpPackage:
                         f"versioning practice of bumping micro rather than minor "
                         f"release numbers. Consider adjusting "
                         f"the minimum allowed version of {self.name} manually.",
-                        extra={"markup": True},
                     )
 
         return epoch_major_minor_to_set_of_micro
@@ -147,7 +145,6 @@ class BumpPackage:
                 logger.debug(
                     f"{package_prefix(self.name)} Reconstructed version {version} not found "
                     f"in released versions. Skipping.",
-                    extra={"markup": True},
                 )
 
         return sorted(minor_releases)
@@ -198,7 +195,6 @@ class BumpPackage:
                     f"mapping from versions to release dates, possibly due "
                     f"to non-standard versioning or that the release was "
                     f"yanked or a prerelease. Continuing.",
-                    extra={"markup": True},
                 )
                 continue
 
@@ -223,7 +219,6 @@ class BumpPackage:
         if not supported_releases_before_cooldown and not releases_before_drop_date:
             logger.debug(
                 f"{package_prefix(self.name)} First release is during the cooldown period.",
-                extra={"markup": True},
             )
             return utils.normalize_requirement_string(min(self.released_versions))
 
@@ -243,7 +238,6 @@ class BumpPackage:
             f"{package_prefix(self.name)} "
             f"New minimum version: {str(new_minimum_version)} "
             f"({release_date.isoformat()})",
-            extra={"markup": True},
         )
 
         return utils.normalize_requirement_string(new_minimum_version)
@@ -266,7 +260,6 @@ def combine_requirements(
     if "||" in new_specifier:
         logger.warning(
             "Cannot update versions with multiple != in supported range. Skipping.",
-            extra={"markup": True},
         )
         return None
 
@@ -299,7 +292,6 @@ def get_new_requirement_for_package(
     package = BumpPackage(requirement.name)
     logger.debug(
         f"{package_prefix(requirement.name)} Original specifier: {str(requirement.specifier)}",
-        extra={"markup": True},
     )
     calculated_minimum_version = package.oldest_supported_minor_release(
         drop_months=drop_months,
@@ -308,7 +300,6 @@ def get_new_requirement_for_package(
     time_based_requirement = f">={calculated_minimum_version}"
     logger.debug(
         f"{package_prefix(requirement.name)} Time-based specifier: {time_based_requirement}",
-        extra={"markup": True},
     )
     combined_requirement = combine_requirements(
         original=requirement.specifier,
@@ -322,7 +313,6 @@ def get_new_requirement_for_package(
 
     logger.info(
         f"{package_prefix(requirement.name)} Combined requirement: {new_requirement}",
-        extra={"markup": True},
     )
 
     return new_requirement
@@ -501,14 +491,12 @@ class BumpMinimumDependencies:
                 try:
                     logger.debug(
                         f"{requirement = } is not a Requirement object.",
-                        extra={"markup": True},
                     )
                     requirement = Requirement(requirement)
                 except (InvalidRequirement, TypeError):
                     logger.warning(
                         f"{requirement = } cannot be converted into a "
                         f"Requirement. Continuing",
-                        extra={"markup": True},
                     )
                     continue
 
@@ -527,7 +515,6 @@ class BumpMinimumDependencies:
             logger.debug(
                 "Requirements to update: "
                 f"{', '.join([str(requirement) for requirement in requirements_to_update])}",
-                extra={"markup": True},
             )
 
         packages_with_markers: list[str] = []
@@ -550,13 +537,11 @@ class BumpMinimumDependencies:
             except NoReleasesError:
                 logger.warning(
                     f"{package_prefix(requirement.name)} No releases identified from PyPI. Skipping.",
-                    extra={"markup": True},
                 )
             except requests.exceptions.JSONDecodeError:
                 logger.warning(
                     f"{package_prefix(requirement.name)} Cannot decode JSON metadata from "
                     f"PyPI. Skipping.",
-                    extra={"markup": True},
                 )
             # Catch all other exceptions since if a package cannot be updated
             # for whatever reason, it should be skipped with a warning issued.
@@ -627,11 +612,9 @@ class BumpMinimumDependencies:
                 logger.error(
                     f"Command failed: {command_string}",
                     exc_info=exc_info,
-                    extra={"markup": True},
                 )
                 logger.warning(
                     f"Update not performed: {new_requirement}. Continuing.",
-                    extra={"markup": True},
                 )
 
     def bump_core_requirements(self) -> None:

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -25,7 +25,7 @@ from packaging.requirements import Requirement
 
 
 from bump_minimum_dependencies.pyproject import PyProject
-from bump_minimum_dependencies.logging import logger, package_prefix
+from bump_minimum_dependencies.logging import logger, package_prefix, log_uv_command
 from bump_minimum_dependencies import utils
 
 import math
@@ -94,7 +94,10 @@ class BumpPackage:
 
             if (epoch, major, minor) not in epoch_major_minor_to_set_of_micro:
                 if version.post is not None:
-                    logger.info(f"{package_prefix(self.name)} Skipping post release: {str(version)}")
+                    logger.info(
+                        f"{package_prefix(self.name)} Skipping post release: {str(version)}",
+                        extra={"markup": True},
+                    )
                     continue
                 epoch_major_minor_to_set_of_micro[(epoch, major, minor)] = {micro}
             else:
@@ -120,7 +123,8 @@ class BumpPackage:
                         f"between {first_patch} and {last_patch}, suggesting a "
                         f"versioning practice of bumping micro rather than minor "
                         f"release numbers. Consider adjusting "
-                        f"the minimum allowed version of {self.name} manually."
+                        f"the minimum allowed version of {self.name} manually.",
+                        extra={"markup": True},
                     )
 
         return epoch_major_minor_to_set_of_micro
@@ -142,7 +146,8 @@ class BumpPackage:
             else:
                 logger.debug(
                     f"{package_prefix(self.name)} Reconstructed version {version} not found "
-                    f"in released versions. Skipping."
+                    f"in released versions. Skipping.",
+                    extra={"markup": True},
                 )
 
         return sorted(minor_releases)
@@ -192,7 +197,8 @@ class BumpPackage:
                     f"{package_prefix(self.name)} Version {str(release)} is not in the "
                     f"mapping from versions to release dates, possibly due "
                     f"to non-standard versioning or that the release was "
-                    f"yanked or a prerelease. Continuing."
+                    f"yanked or a prerelease. Continuing.",
+                    extra={"markup": True},
                 )
                 continue
 
@@ -202,14 +208,23 @@ class BumpPackage:
                 releases_before_drop_date.append(release)
 
         if not supported_releases_before_cooldown:
-            logger.debug(f"{package_prefix(self.name)} No supported releases before cooldown.")
+            logger.debug(
+                f"{package_prefix(self.name)} No supported releases before cooldown.",
+                extra={"markup": True},
+            )
 
         if not releases_before_drop_date:
-            logger.debug(f"{package_prefix(self.name)} No releases before drop date.")
+            logger.debug(
+                f"{package_prefix(self.name)} No releases before drop date.",
+                extra={"markup": True},
+            )
 
         # when a package's first release is during the cooldown period
         if not supported_releases_before_cooldown and not releases_before_drop_date:
-            logger.debug(f"{package_prefix(self.name)} First release is during the cooldown period.")
+            logger.debug(
+                f"{package_prefix(self.name)} First release is during the cooldown period.",
+                extra={"markup": True},
+            )
             return utils.normalize_requirement_string(min(self.released_versions))
 
         new_minimum_version = min(
@@ -224,10 +239,10 @@ class BumpPackage:
             new_minimum_version
         ]
 
-        logger.info(   # FIXME
+        logger.info(
             f"{package_prefix(self.name)} "
             f"New minimum version: {str(new_minimum_version)} "
-            f"({release_date.isoformat()}).",
+            f"({release_date.isoformat()})",
             extra={"markup": True},
         )
 
@@ -250,7 +265,8 @@ def combine_requirements(
     new_specifier = str(original) if combined.is_empty() else str(combined)
     if "||" in new_specifier:
         logger.warning(
-            "Cannot update versions with multiple != in supported range; skipping."
+            "Cannot update versions with multiple != in supported range. Skipping.",
+            extra={"markup": True},
         )
         return None
 
@@ -282,14 +298,18 @@ def get_new_requirement_for_package(
     """Combine the time-based requirement with the original requirement."""
     package = BumpPackage(requirement.name)
     logger.debug(
-        f"{package_prefix(requirement.name)} Original specifier: {str(requirement.specifier)}"
+        f"{package_prefix(requirement.name)} Original specifier: {str(requirement.specifier)}",
+        extra={"markup": True},
     )
     calculated_minimum_version = package.oldest_supported_minor_release(
         drop_months=drop_months,
         cooldown_months=cooldown_months,
     )
     time_based_requirement = f">={calculated_minimum_version}"
-    logger.debug(f"{package_prefix(requirement.name)} Time-based specifier: {time_based_requirement}")
+    logger.debug(
+        f"{package_prefix(requirement.name)} Time-based specifier: {time_based_requirement}",
+        extra={"markup": True},
+    )
     combined_requirement = combine_requirements(
         original=requirement.specifier,
         new=time_based_requirement,
@@ -300,7 +320,10 @@ def get_new_requirement_for_package(
     else:
         new_requirement = f"{requirement.name}{combined_requirement}"
 
-    logger.info(f"[{requirement.name}] Combined requirement: {new_requirement}")
+    logger.info(
+        f"{package_prefix(requirement.name)} Combined requirement: {new_requirement}",
+        extra={"markup": True},
+    )
 
     return new_requirement
 
@@ -363,14 +386,13 @@ class BumpMinimumDependencies:
             "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"
         ] = "WARNING",
     ):
-        logger.debug(f"Setting logging level to {verbosity}")
         logger.setLevel(verbosity)
 
         if cooldown_months > drop_months:
             # issue a warning when cooldown_months ≠ the default value
             if cooldown_months != 12:
                 msg = f"Reducing cooldown_months to {drop_months} to equal drop_months."
-                logger.warning(msg)
+                logger.warning(msg, extra={"markup": True})
 
             cooldown_months = drop_months
 
@@ -398,7 +420,9 @@ class BumpMinimumDependencies:
         if self.project_name:
             self.packages_to_skip.append(self.project_name)
 
-        logger.info(f"Bumping minimum dependencies for {pyproject_file}")
+        logger.info(
+            f"Bumping minimum dependencies for {pyproject_file}", extra={"markup": True}
+        )
 
     @property
     def project_name(self) -> str | None:
@@ -419,7 +443,7 @@ class BumpMinimumDependencies:
                 f"{self.pyproject_file!r}; no updates to core project"
                 f"dependencies made."
             )
-            logger.warning(msg)
+            logger.warning(msg, extra={"markup": True})
 
         core_requirements_to_update: set[Requirement] = set()
         for requirement in all_requirements:
@@ -475,12 +499,16 @@ class BumpMinimumDependencies:
             # and is intended as a safeguard.
             if not isinstance(requirement, Requirement):
                 try:
-                    logger.debug(f"{requirement = } is not a Requirement object.")
+                    logger.debug(
+                        f"{requirement = } is not a Requirement object.",
+                        extra={"markup": True},
+                    )
                     requirement = Requirement(requirement)
                 except (InvalidRequirement, TypeError):
                     logger.warning(
                         f"{requirement = } cannot be converted into a "
-                        f"Requirement. Continuing"
+                        f"Requirement. Continuing",
+                        extra={"markup": True},
                     )
                     continue
 
@@ -495,10 +523,12 @@ class BumpMinimumDependencies:
 
             requirements_to_update.append(requirement)
 
-        logger.debug(
-            "Requirements to update: "
-            f"{', '.join([str(requirement) for requirement in requirements_to_update])}"
-        )
+        if requirements_to_update:
+            logger.debug(
+                "Requirements to update: "
+                f"{', '.join([str(requirement) for requirement in requirements_to_update])}",
+                extra={"markup": True},
+            )
 
         packages_with_markers: list[str] = []
         for requirement in requirements_to_update:
@@ -508,7 +538,7 @@ class BumpMinimumDependencies:
         new_requirements: list[str] = []
         for requirement in requirements_to_update:
             if requirement.name.lower() in packages_with_markers:
-                logger.debug(str(requirement))
+                logger.debug(str(requirement), extra={"markup": True})
                 continue
 
             try:
@@ -519,12 +549,14 @@ class BumpMinimumDependencies:
                 )
             except NoReleasesError:
                 logger.warning(
-                    f"{package_prefix(requirement.name)} No releases identified from PyPI; skipping."
+                    f"{package_prefix(requirement.name)} No releases identified from PyPI. Skipping.",
+                    extra={"markup": True},
                 )
             except requests.exceptions.JSONDecodeError:
                 logger.warning(
                     f"{package_prefix(requirement.name)} Cannot decode JSON metadata from "
-                    f"PyPI; skipping.",
+                    f"PyPI. Skipping.",
+                    extra={"markup": True},
                 )
             # Catch all other exceptions since if a package cannot be updated
             # for whatever reason, it should be skipped with a warning issued.
@@ -532,7 +564,9 @@ class BumpMinimumDependencies:
                 warning_message = (
                     f"{package_prefix(requirement.name)} Unable to update requirement. Skipping.",
                 )
-                logger.warning(warning_message, exc_info=exc_info)
+                logger.warning(
+                    warning_message, exc_info=exc_info, extra={"markup": True}
+                )
             else:
                 if not new_requirement:
                     continue
@@ -569,7 +603,7 @@ class BumpMinimumDependencies:
 
         if not new_requirements:
             msg = f"No updates to requirements for {clause}."
-            logger.info(msg)
+            logger.info(msg, extra={"markup": True})
             return
 
         for new_requirement in new_requirements:
@@ -585,9 +619,7 @@ class BumpMinimumDependencies:
             ]
 
             command_string = " ".join(command)
-
-            msg = f"Running: {command_string}"
-            logger.info(msg)
+            log_uv_command(command)
 
             try:
                 subprocess.run(command, check=True, capture_output=True)
@@ -595,8 +627,12 @@ class BumpMinimumDependencies:
                 logger.error(
                     f"Command failed: {command_string}",
                     exc_info=exc_info,
+                    extra={"markup": True},
                 )
-                logger.warning(f"Update not performed: {new_requirement}. Continuing.")
+                logger.warning(
+                    f"Update not performed: {new_requirement}. Continuing.",
+                    extra={"markup": True},
+                )
 
     def bump_core_requirements(self) -> None:
         """Bump the core package requirements."""

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -25,7 +25,7 @@ from packaging.requirements import Requirement
 
 
 from bump_minimum_dependencies.pyproject import PyProject
-from bump_minimum_dependencies.logging import logger
+from bump_minimum_dependencies.logging import logger, package_prefix
 from bump_minimum_dependencies import utils
 
 import math
@@ -94,7 +94,7 @@ class BumpPackage:
 
             if (epoch, major, minor) not in epoch_major_minor_to_set_of_micro:
                 if version.post is not None:
-                    logger.info(f"[{self.name}] Skipping post release: {str(version)}")
+                    logger.info(f"{package_prefix(self.name)} Skipping post release: {str(version)}")
                     continue
                 epoch_major_minor_to_set_of_micro[(epoch, major, minor)] = {micro}
             else:
@@ -141,7 +141,7 @@ class BumpPackage:
                 minor_releases.append(version)
             else:
                 logger.debug(
-                    f"[{self.name}] Reconstructed version {version} not found "
+                    f"{package_prefix(self.name)} Reconstructed version {version} not found "
                     f"in released versions. Skipping."
                 )
 
@@ -189,10 +189,10 @@ class BumpPackage:
                 release_date: datetime.date = self.versions_to_release_dates[release]
             except KeyError:
                 logger.debug(
-                    f"Version {str(release)} is not in the "
+                    f"{package_prefix(self.name)} Version {str(release)} is not in the "
                     f"mapping from versions to release dates, possibly due "
                     f"to non-standard versioning or that the release was "
-                    f"yanked or a prerelease. Continuing. [{self.name}]"
+                    f"yanked or a prerelease. Continuing."
                 )
                 continue
 
@@ -202,14 +202,14 @@ class BumpPackage:
                 releases_before_drop_date.append(release)
 
         if not supported_releases_before_cooldown:
-            logger.debug(f"[{self.name}] No supported releases before cooldown.")
+            logger.debug(f"{package_prefix(self.name)} No supported releases before cooldown.")
 
         if not releases_before_drop_date:
-            logger.debug(f"[{self.name}] No releases before drop date.")
+            logger.debug(f"{package_prefix(self.name)} No releases before drop date.")
 
         # when a package's first release is during the cooldown period
         if not supported_releases_before_cooldown and not releases_before_drop_date:
-            logger.debug(f"[{self.name}] First release is during the cooldown period.")
+            logger.debug(f"{package_prefix(self.name)} First release is during the cooldown period.")
             return utils.normalize_requirement_string(min(self.released_versions))
 
         new_minimum_version = min(
@@ -224,8 +224,8 @@ class BumpPackage:
             new_minimum_version
         ]
 
-        logger.info(
-            f"[blue]({self.name.strip()})[/] "
+        logger.info(   # FIXME
+            f"{package_prefix(self.name)} "
             f"New minimum version: {str(new_minimum_version)} "
             f"({release_date.isoformat()}).",
             extra={"markup": True},
@@ -282,14 +282,14 @@ def get_new_requirement_for_package(
     """Combine the time-based requirement with the original requirement."""
     package = BumpPackage(requirement.name)
     logger.debug(
-        f"[{requirement.name}] Original specifier: {str(requirement.specifier)}"
+        f"{package_prefix(requirement.name)} Original specifier: {str(requirement.specifier)}"
     )
     calculated_minimum_version = package.oldest_supported_minor_release(
         drop_months=drop_months,
         cooldown_months=cooldown_months,
     )
     time_based_requirement = f">={calculated_minimum_version}"
-    logger.debug(f"[{requirement.name}] Time-based specifier: {time_based_requirement}")
+    logger.debug(f"{package_prefix(requirement.name)} Time-based specifier: {time_based_requirement}")
     combined_requirement = combine_requirements(
         original=requirement.specifier,
         new=time_based_requirement,
@@ -519,18 +519,18 @@ class BumpMinimumDependencies:
                 )
             except NoReleasesError:
                 logger.warning(
-                    f"[{requirement.name}] No releases identified from PyPI; skipping."
+                    f"{package_prefix(requirement.name)} No releases identified from PyPI; skipping."
                 )
             except requests.exceptions.JSONDecodeError:
                 logger.warning(
-                    f"[{requirement.name}] Cannot decode JSON metadata from "
+                    f"{package_prefix(requirement.name)} Cannot decode JSON metadata from "
                     f"PyPI; skipping.",
                 )
             # Catch all other exceptions since if a package cannot be updated
             # for whatever reason, it should be skipped with a warning issued.
             except Exception as exc_info:
                 warning_message = (
-                    f"[{requirement.name}] Unable to update requirement. Skipping.",
+                    f"{package_prefix(requirement.name)} Unable to update requirement. Skipping.",
                 )
                 logger.warning(warning_message, exc_info=exc_info)
             else:

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -3,7 +3,6 @@ __all__ = [
     "BumpPackage",
     "combine_requirements",
     "get_new_requirement_for_package",
-    "logger",
     "requirement_already_included",
 ]
 
@@ -25,9 +24,8 @@ from packaging.requirements import Requirement
 
 
 from bump_minimum_dependencies.pyproject import PyProject
-from . import utils
-
-import logging
+from bump_minimum_dependencies.logging import logger
+from bump_minimum_dependencies import utils
 
 import math
 
@@ -35,11 +33,6 @@ import subprocess
 import functools
 
 DAYS_PER_MONTH = 30.436875
-
-
-logger = logging.getLogger("bump")
-logger.propagate = True
-logger.setLevel(logging.WARNING)
 
 
 class NoReleasesError(Exception):

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -191,7 +191,8 @@ class BumpPackage:
                 release_date: datetime.date = self.versions_to_release_dates[release]
             except KeyError:
                 logger.debug(
-                    f"{package_prefix(self.name)} Version {str(release)} is not in the "
+                    f"{package_prefix(self.name)} "
+                    f"Version {str(release)} is not in the "
                     f"mapping from versions to release dates, possibly due "
                     f"to non-standard versioning or that the release was "
                     f"yanked or a prerelease. Continuing.",
@@ -205,14 +206,15 @@ class BumpPackage:
 
         if not supported_releases_before_cooldown:
             logger.debug(
-                f"{package_prefix(self.name)} No supported releases before cooldown.",
-                extra={"markup": True},
+                f"{package_prefix(self.name)} "
+                f"No supported releases prior to cooldown. "
+                f"({cooldown_date.isoformat()})",
             )
 
         if not releases_before_drop_date:
             logger.debug(
-                f"{package_prefix(self.name)} No releases before drop date.",
-                extra={"markup": True},
+                f"{package_prefix(self.name)} "
+                f"No releases prior to drop date ({drop_date.isoformat()}).",
             )
 
         # when a package's first release is during the cooldown period
@@ -581,7 +583,7 @@ class BumpMinimumDependencies:
             clause = f"dependency group {dependency_group!r}"
         elif extras_category:
             flag = [f"--optional={extras_category}"]
-            clause = f"optional dependencies category {extras_category}"
+            clause = f"optional dependencies category {extras_category!r}"
         else:
             flag = []
             clause = "core dependencies"

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -7,6 +7,7 @@ __all__ = [
 ]
 
 import pathlib
+from typing import Literal
 
 import click
 import requests
@@ -355,7 +356,13 @@ class BumpMinimumDependencies:
         group: tuple[str, ...] | list[str] = (),
         skip_package: tuple[str, ...] | list[str] = (),
         only_package: tuple[str, ...] | list[str] = (),
+        verbosity: Literal[
+            "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"
+        ] = "WARNING",
     ):
+        logger.debug(f"Setting logging level to {verbosity}")
+        logger.setLevel(verbosity)
+
         if cooldown_months > drop_months:
             # issue a warning when cooldown_months ≠ the default value
             if cooldown_months != 12:

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -574,7 +574,7 @@ class BumpMinimumDependencies:
         *,
         dependency_group: str | None = None,
         extras_category: str | None = None,
-    ):
+    ) -> None:
         if dependency_group and extras_category:
             raise ValueError("Cannot set both dependency_group and extras_category.")
 
@@ -624,21 +624,21 @@ class BumpMinimumDependencies:
         new_requirements = self.get_new_requirements(self.core_requirements_to_update)
         self.run_uv_commands(new_requirements)
 
-    def bump_dependency_groups(self):
+    def bump_dependency_groups(self) -> None:
         """Bump requirements in dependency groups."""
         for dependency_group in self.dependency_groups_to_update:
             requirements = self.pyproject.dependency_groups[dependency_group]
             new_requirements = self.get_new_requirements(requirements)
             self.run_uv_commands(new_requirements, dependency_group=dependency_group)
 
-    def bump_optional_dependencies(self):
+    def bump_optional_dependencies(self) -> None:
         """Bump requirements in optional dependencies."""
         for category in self.optional_categories_to_update:
             requirements = self.pyproject.optional_dependencies[category]
             new_requirements = self.get_new_requirements(requirements)
             self.run_uv_commands(new_requirements, extras_category=category)
 
-    def run(self):
+    def run(self) -> None:
         """Perform all the requested and necessary updates."""
         self.bump_core_requirements()
         self.bump_dependency_groups()

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -58,7 +58,6 @@ class BumpPackage:
             skip_yanked=True,
             skip_prerelease=True,
         )
-        logger.debug(f"Finding new minimum allowed version for {self.name}")
 
     @functools.cached_property
     def response(self):
@@ -95,9 +94,7 @@ class BumpPackage:
 
             if (epoch, major, minor) not in epoch_major_minor_to_set_of_micro:
                 if version.post is not None:
-                    logger.warning(
-                        f"Skipping post release of {self.name}: {str(version)}"
-                    )
+                    logger.info(f"[{self.name}] Skipping post release: {str(version)}")
                     continue
                 epoch_major_minor_to_set_of_micro[(epoch, major, minor)] = {micro}
             else:
@@ -144,8 +141,8 @@ class BumpPackage:
                 minor_releases.append(version)
             else:
                 logger.debug(
-                    f"Reconstructed version {version} not found "
-                    f"in released versions. Skipping. [{self.name}]"
+                    f"[{self.name}] Reconstructed version {version} not found "
+                    f"in released versions. Skipping."
                 )
 
         return sorted(minor_releases)
@@ -171,7 +168,7 @@ class BumpPackage:
         """
 
         if not self.minor_releases:
-            msg = f"No releases identified for {self.name}."
+            msg = f"[{self.name}] No minor releases identified."
             raise NoReleasesError(msg)
 
         support_window = datetime.timedelta(
@@ -205,14 +202,14 @@ class BumpPackage:
                 releases_before_drop_date.append(release)
 
         if not supported_releases_before_cooldown:
-            logger.debug(f"No supported releases before cooldown. [{self.name}]")
+            logger.debug(f"[{self.name}] No supported releases before cooldown.")
 
         if not releases_before_drop_date:
-            logger.debug(f"No releases before drop date. [{self.name}]")
+            logger.debug(f"[{self.name}] No releases before drop date.")
 
         # when a package's first release is during the cooldown period
         if not supported_releases_before_cooldown and not releases_before_drop_date:
-            logger.debug(f"First release is during the cooldown period. [{self.name}]")
+            logger.debug(f"[{self.name}] First release is during the cooldown period.")
             return utils.normalize_requirement_string(min(self.released_versions))
 
         minimum_allowed_requirement = utils.normalize_requirement_string(
@@ -223,10 +220,6 @@ class BumpPackage:
                     default=min(self.minor_releases),
                 ),
             )
-        )
-
-        logger.info(
-            f"Oldest supported release: {minimum_allowed_requirement} [{self.name}]"
         )
 
         return minimum_allowed_requirement
@@ -278,15 +271,16 @@ def get_new_requirement_for_package(
     cooldown_months: float | int,
 ) -> str | None:
     """Combine the time-based requirement with the original requirement."""
-    logger.debug(f"Getting new requirement for {requirement.name}")
     package = BumpPackage(requirement.name)
-    logger.debug(f"Pre-existing requirement: {str(requirement)}")
+    logger.debug(
+        f"[{requirement.name}] Original specifier: {str(requirement.specifier)}"
+    )
     calculated_minimum_version = package.oldest_supported_minor_release(
         drop_months=drop_months,
         cooldown_months=cooldown_months,
     )
     time_based_requirement = f">={calculated_minimum_version}"
-    logger.debug(f"Time-based requirement: {requirement.name}{time_based_requirement}")
+    logger.debug(f"[{requirement.name}] Time-based specifier: {time_based_requirement}")
     combined_requirement = combine_requirements(
         original=requirement.specifier,
         new=time_based_requirement,
@@ -297,7 +291,7 @@ def get_new_requirement_for_package(
     else:
         new_requirement = f"{requirement.name}{combined_requirement}"
 
-    logger.debug(f"Combined requirement: {new_requirement}")
+    logger.info(f"[{requirement.name}] Combined requirement: {new_requirement}")
 
     return new_requirement
 
@@ -472,10 +466,10 @@ class BumpMinimumDependencies:
             # and is intended as a safeguard.
             if not isinstance(requirement, Requirement):
                 try:
-                    logger.warning(f"{requirement = } is not a Requirement object.")
+                    logger.debug(f"{requirement = } is not a Requirement object.")
                     requirement = Requirement(requirement)
                 except (InvalidRequirement, TypeError):
-                    logger.error(
+                    logger.warning(
                         f"{requirement = } cannot be converted into a "
                         f"Requirement. Continuing"
                     )

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -581,11 +581,7 @@ class BumpMinimumDependencies:
             logger.info(msg)
 
             try:
-                subprocess.run(
-                    command,
-                    check=True,
-                    capture_output=True,
-                )
+                subprocess.run(command, check=True, capture_output=True)
             except subprocess.CalledProcessError as exc_info:
                 logger.error(
                     f"Command failed: {command_string}",

--- a/src/bump_minimum_dependencies/logging.py
+++ b/src/bump_minimum_dependencies/logging.py
@@ -2,9 +2,23 @@ __all__ = ["logger", "package_prefix"]
 
 import logging
 from rich.logging import RichHandler
+from rich.markup import escape
 
+keywords = [
+    "Skipping.",
+    "Continuing.",
+    "Requirements to update:",
+    "frozen",
+    "quiet",
+    "Combined requirement:",
+]
 
-rich_handler = RichHandler(rich_tracebacks=False, show_time=False)
+rich_handler = RichHandler(
+    rich_tracebacks=False,
+    show_time=False,
+    markup=True,
+    keywords=keywords,
+)
 
 
 logging.basicConfig(
@@ -17,4 +31,14 @@ logger = logging.getLogger("bump-minimum-dependencies")
 
 
 def package_prefix(package: str) -> str:
-    return f"[{package}] ****"   # add formatting
+    raw_prefix = f"[{package}]"
+    return f"[magenta]{escape(raw_prefix)}[/magenta]"
+
+
+def log_uv_command(command: list[str]):
+    command_string = " ".join(command)
+
+    logger.info(
+        f"Running: [bold]{command_string}[/bold]",
+        extra={"markup": True},
+    )

--- a/src/bump_minimum_dependencies/logging.py
+++ b/src/bump_minimum_dependencies/logging.py
@@ -1,0 +1,9 @@
+__all__ = ["logger"]
+
+import logging
+
+
+
+logger = logging.getLogger("bump")
+logger.propagate = True
+logger.setLevel(logging.WARNING)

--- a/src/bump_minimum_dependencies/logging.py
+++ b/src/bump_minimum_dependencies/logging.py
@@ -1,4 +1,4 @@
-__all__ = ["logger"]
+__all__ = ["logger", "package_prefix"]
 
 import logging
 from rich.logging import RichHandler
@@ -14,3 +14,7 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger("bump-minimum-dependencies")
+
+
+def package_prefix(package: str) -> str:
+    return f"[{package}] ****"   # add formatting

--- a/src/bump_minimum_dependencies/logging.py
+++ b/src/bump_minimum_dependencies/logging.py
@@ -18,6 +18,7 @@ rich_handler = RichHandler(
     show_time=False,
     markup=True,
     keywords=keywords,
+    show_path=False,  # set to True when actively debugging
 )
 
 

--- a/src/bump_minimum_dependencies/logging.py
+++ b/src/bump_minimum_dependencies/logging.py
@@ -1,9 +1,15 @@
 __all__ = ["logger"]
 
 import logging
+from rich.logging import RichHandler
 
 
+rich_handler = RichHandler(rich_tracebacks=False)
 
-logger = logging.getLogger("bump")
-logger.propagate = True
-logger.setLevel(logging.WARNING)
+logging.basicConfig(
+    format="%(message)s",
+    datefmt="[%X]",
+    handlers=[rich_handler],
+)
+
+logger = logging.getLogger("bump-minimum-dependencies")

--- a/src/bump_minimum_dependencies/logging.py
+++ b/src/bump_minimum_dependencies/logging.py
@@ -4,7 +4,8 @@ import logging
 from rich.logging import RichHandler
 
 
-rich_handler = RichHandler(rich_tracebacks=False)
+rich_handler = RichHandler(rich_tracebacks=False, show_time=False)
+
 
 logging.basicConfig(
     format="%(message)s",

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -6,6 +6,7 @@ import click
 
 from . import bump
 
+from typing import Literal
 
 DEFAULT_DROP_MONTHS = 24
 DEFAULT_COOLDOWN_MONTHS = 12
@@ -95,6 +96,14 @@ DEFAULT_SKIP_CORE = False
     is_flag=True,
     help="If provided, core project dependencies will not be updated.",
 )
+@click.option(
+    "--verbosity",
+    default="WARNING",
+    type=click.Choice(
+        ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"],
+    ),
+    help="Logging verbosity level. Defaults to WARNING.",
+)
 @click.version_option(package_name="bump_minimum_dependencies")
 def main(
     pyproject_file: str | pathlib.Path,
@@ -107,6 +116,7 @@ def main(
     group: tuple[str, ...] | list[str],
     skip_package: tuple[str, ...] | list[str],
     only_package: tuple[str, ...] | list[str],
+    verbosity: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"],
 ) -> None:
     """
     Bump the minimum allowed minor versions of package dependencies.
@@ -137,6 +147,7 @@ def main(
         skip_package=skip_package,
         skip_core=skip_core,
         only_package=only_package,
+        verbosity=verbosity,
     )
 
     bump_minimum_dependencies.run()

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -3,10 +3,10 @@ import shutil
 
 from bump_minimum_dependencies import bump
 import pytest
-import logging
 from pathlib import Path
 
-bump.logger.setLevel(logging.DEBUG)
+
+DEFAULT_TEST_VERBOSITY = "DEBUG"
 
 
 def get_errmsg_from_file_comparison(
@@ -48,12 +48,21 @@ def get_errmsg_from_file_comparison(
 @pytest.mark.parametrize(
     "subdir,date,kwargs",
     [
-        ("base_case", "2026-01-01", {"drop_months": 24, "cooldown_months": 21}),
+        (
+            "base_case",
+            "2026-01-01",
+            {
+                "drop_months": 24,
+                "cooldown_months": 21,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
+            },
+        ),
         (
             "no_project_table",
             "2026-08-18",
             {
                 "group": ["group"],
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
         (
@@ -62,6 +71,7 @@ def get_errmsg_from_file_comparison(
             {
                 "drop_months": 12,
                 "cooldown_months": 0,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
         (
@@ -70,6 +80,7 @@ def get_errmsg_from_file_comparison(
             {
                 "drop_months": 360,
                 "cooldown_months": 360,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
         (
@@ -80,32 +91,58 @@ def get_errmsg_from_file_comparison(
                 "cooldown_months": 6,
                 "all_groups": True,
                 "all_extras": True,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
         (
             "bump_all_dependency_groups",
             "2026-01-01",
-            {"drop_months": 24, "cooldown_months": 21, "all_groups": True},
+            {
+                "drop_months": 24,
+                "cooldown_months": 21,
+                "all_groups": True,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
+            },
         ),
         (
             "bump_all_optionals",
             "2026-01-01",
-            {"all_extras": True, "drop_months": 24, "cooldown_months": 12},
+            {
+                "all_extras": True,
+                "drop_months": 24,
+                "cooldown_months": 12,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
+            },
         ),
         (
             "trailing_dot_zero",
             "2026-01-01",
-            {"all_extras": True, "drop_months": 24, "cooldown_months": 12},
+            {
+                "all_extras": True,
+                "drop_months": 24,
+                "cooldown_months": 12,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
+            },
         ),
         (
             "bump_one_dependency_group",
             "2026-01-01",
-            {"drop_months": 24, "cooldown_months": 21, "group": ["numpy"]},
+            {
+                "drop_months": 24,
+                "cooldown_months": 21,
+                "group": ["numpy"],
+                "verbosity": DEFAULT_TEST_VERBOSITY,
+            },
         ),
         (
             "bump_two_dependency_groups",
             "2026-01-01",
-            {"drop_months": 24, "cooldown_months": 21, "group": ["astropy", "numpy"]},
+            {
+                "drop_months": 24,
+                "cooldown_months": 21,
+                "group": ["astropy", "numpy"],
+                "verbosity": DEFAULT_TEST_VERBOSITY,
+            },
         ),
         (
             "bump_only_package",
@@ -116,6 +153,7 @@ def get_errmsg_from_file_comparison(
                 "group": ["update"],
                 "extra": ["update"],
                 "only_package": ["numpy"],
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
         (
@@ -126,6 +164,7 @@ def get_errmsg_from_file_comparison(
                 "cooldown_months": 6,
                 "all_groups": True,
                 "all_extras": True,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
         (
@@ -136,6 +175,7 @@ def get_errmsg_from_file_comparison(
                 "cooldown_months": 12,
                 "all_groups": True,
                 "all_extras": True,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
         (
@@ -146,6 +186,7 @@ def get_errmsg_from_file_comparison(
                 "cooldown_months": 360,
                 "all_groups": True,
                 "all_extras": True,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
         (
@@ -156,6 +197,7 @@ def get_errmsg_from_file_comparison(
                 "cooldown_months": 6,
                 "all_groups": True,
                 "all_extras": True,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
         (
@@ -166,6 +208,7 @@ def get_errmsg_from_file_comparison(
                 "cooldown_months": 0,
                 "all_groups": True,
                 "all_extras": True,
+                "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
     ],

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,7 @@ dependencies = [
     { name = "click" },
     { name = "dep-logic" },
     { name = "requests" },
+    { name = "rich" },
     { name = "uv" },
 ]
 
@@ -56,6 +57,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.4.2,<9" },
     { name = "dep-logic", specifier = ">=0.7.1" },
     { name = "requests", specifier = ">=2.34.2" },
+    { name = "rich", specifier = ">=15.0.0" },
     { name = "uv", specifier = ">=0.12.5" },
 ]
 


### PR DESCRIPTION
 - Moved logging setup to new `logging.py` module for separation of concerns.
 - Enabled rich text formatting with `rich` for logger.
 - Made prefix usage more consistent in logger messagas.
 - Added a verbosity flag, so that we can now do `bump-minimum-dependencies --verbosity=DEBUG` if we want to maximize verbositudinality.