### PR TITLE
Adjust the micro version number for `0.*` releases and when there are lots of micro releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,16 @@ Inspired by [SPEC 0]. 🧪
 ```groff
 Usage: bump-minimum-dependencies [OPTIONS]
 
-  Bump the minimum allowed minor versions of package dependencies.
+  Bump minimum allowed versions of package dependencies in pyproject.toml.
 
   This tool updates pyproject.toml via `uv add --frozen` to drop support for
   minor versions of package dependencies based on the time since the minor
   version was first released, where package versions may be given by
-  `<MAJOR>.<MINOR>` or `<MAJOR>.<MINOR>.<PATCH>`. Additional constraints such
-  as upper limits are preserved.
+  `<MAJOR>.<MINOR>` or `<MAJOR>.<MINOR>.<MICRO>`.
 
-  For example, if version `3.4.0` of a package dependency was released 25
-  months ago and version `3.5.0` was released 23 months ago, running `bump-
-  minimum-dependencies` will update the requirement from `>=3.4.0` to
-  `>=3.5.0`.
+  When a `<MAJOR>.<MINOR>` release has numerous micro releases or for pre-1.0
+  releases, `<MICRO>` might also be bumped to the last release prior to the
+  drop date. Additional constraints such as upper limits are preserved.
 
   Requirements with markers or that cannot be updated will be skipped with a
   warning.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ If you discover a bug, please [raise an issue] with a minimal reproducible examp
   uvx --python=3.14 --with=setuptools nep29 --n_minor=1 --n_months=12 scipy
   ```
 
-
 [dep-logic]: https://github.com/pdm-project/dep-logic
 [nep 29]: https://github.com/hmaarrfk/nep29
 [raise an issue]: https://github.com/namurphy/bump-minimum-dependencies/issues/new

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Inspired by [SPEC 0]. 🧪
 ## Motivation
 
 Determining the minimum requirements of a Python package requires balancing competing tradeoffs.
-Lengthly support windows increase maintenance burden, prevent developers from using new features and assuming bugfixes, and lead to more complicated code.
+Lengthy support windows increase maintenance burden, prevent developers from using new features and assuming bugfixes, and lead to more complicated code.
 Short support windows increase the risk of dependency conflicts.
 Automatically bumping minimum requirements in a predictable way saves time and balances these tradeoffs.
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ bump-minimum-dependencies --extra dev
 
 - This tool invokes `uv add --frozen` to update dependencies in `pyproject.toml` without updating lock files or syncing virtual environments. Requirements may be normalized upon updates.
 
-- If the time-based requirement is mutually exclusive with the original requirement, the original requirement will be preserved.
+- Using [dep-logic] allows bump-minimum-dependencies to handle a wide variety of requirements specifiers and perform logical operations to combine multiple requirements specifiers. For example, `>=4.1,<5` and `>=4.2` will be combined into `>=4.2,<5`.
+
+  - If the time-based requirement is mutually exclusive with the original requirement, the original requirement will be preserved.
 
 - Requirements that cannot be updated will be skipped.
-
-- Using [dep-logic] allows bump-minimum-dependencies to handle a wide variety of requirements specifiers and perform logical operations to combine multiple requirements specifiers. For example, `>=4.1,<5` and `>=4.2` will be combined into `>=4.2,<5`.
 
 ## Limitations and caveats
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # bump-minimum-dependencies
 
-Automatically bump the minimum allowed minor versions of Python package dependencies based on the time since first release, with a cooldown period. ⬆️
+Automatically bump the minimum allowed versions of dependencies in `pyproject.toml` based on the time since first release, with a cooldown period. ⬆️
 
 Inspired by [SPEC 0]. 🧪
+
+## Motivation
+
+Determining the minimum requirements of a Python package requires balancing competing tradeoffs.
+Support windows that are too long increase the maintenance burden, prevent developers from using new features and assuming bugfixes, and lead to more complicated code to account for various contingencies.
+Support windows that are too brief increase the risk of dependency conflicts.
+The maintenance burden is further increased when developers repeatedly discuss when to drop dependencies.
+Automatically bumping minimum requirements in a predictable way saves time and balances these tradeoffs.
 
 ## Usage
 
@@ -108,42 +116,23 @@ bump-minimum-dependencies --extra dev
 
 - Please review and test all updates to `pyproject.toml` before accepting them.
 
-- This tool invokes `uv add --frozen` to update dependencies in `pyproject.toml` without updating lock files or syncing virtual environments.
+  - Use uv's `lowest-direct` [resolution strategy] to run tests in an environment containing the minimum versions of direct dependencies.
 
-- Using [`dep-logic`](https://github.com/pdm-project/dep-logic) allows bump-minimum-dependencies to handle a wide variety of requirements specifiers and perform logical operations to combine multiple requirements specifiers. For example, `>=4.1,<5` and `>=4.2` will be combined into `>=4.2,<5`. Some requirements might not be updated, such as those using `==` or `~=`.
+- This tool invokes `uv add --frozen` to update dependencies in `pyproject.toml` without updating lock files or syncing virtual environments. Requirements may be normalized upon updates.
 
 - If the time-based requirement is mutually exclusive with the original requirement, the original requirement will be preserved.
 
-- If a particular requirement cannot be updated, it will be skipped.
+- Requirements that cannot be updated will be skipped.
 
-- Within a given category, dependencies with markers (such as `'setuptools; python_version > "3.11"'`) will not be updated.
-
-- Requirements may be normalized upon updates by `uv add` (e.g., removal of `.0` suffixes and making package names lower case).
+- Using [dep-logic] allows bump-minimum-dependencies to handle a wide variety of requirements specifiers and perform logical operations to combine multiple requirements specifiers. For example, `>=4.1,<5` and `>=4.2` will be combined into `>=4.2,<5`.
 
 ## Limitations and caveats
 
-- This tool may be unable to update certain dependencies that use non-standard [version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers) or use `!=` multiple times.
+- This tool does not guarantee that an environment can be created that includes the minimum allowed versions of all direct dependencies, but this can be tested with `uv lock --resolution=lowest-direct --dry-run`.
 
-- This tool does not guarantee that an environment can be created that includes the minimum allowed versions of all direct dependencies, but this can be tested with `uv lock --resolution=lowest-direct --dry-run` and then manually fixed.
+- Requirements that use `==`, `~=`, or multiple `!=` comparisons or non-standard [version specifiers] might not be updated.
 
-- This tool does not update `build-system.requires`.
-
-## Motivation
-
-Determining the minimum allowed version of a dependency requires balancing competing tradeoffs. ⚖️
-Supporting older versions increases maintenance burden because of the need to support and test a wide range of versions, while also limiting developers from using newer features and assuming bugfixes.
-When the range of allowed versions is too large, code can become more complicated to account for various contingencies.
-Support windows that are too brief increase the risk of dependency conflicts and may cause problems for end users.
-The developer maintenance burden is further increased when developers repeatedly discuss when to drop older versions of dependencies.
-
-[SPEC 0] recommends that projects across the scientific pythoniverse adopt a common time-based policy for dropping support for older versions of dependencies.
-SPEC 0 recommends core package dependencies be dropped 24 months after their initial minor release.
-NumPy `v2.1.0` was released on 2024-08-18, so SPEC 0 recommends that packages drop support for `v2.1.*` of NumPy after 2026-08-18.
-
-A limitation of SPEC 0 is that when a dependency goes more than 24 months between releases, a new release can immediately become the minimum supported version.
-This limitation can be mitigated by providing a cooldown period so that new releases do not become the minimum supported version until a certain time period has passed (such as 12 months).
-
-Because dependency updates have often needed to be performed manually (such as by looking up release times on the Python Package Index and editing `pyproject.toml` accordingly), a tool that automates these updates will save developer time, especially when accounting for edge cases.
+- This tool does not update `build-system.requires` or requirements with markers (such as `'setuptools; python_version > "3.11"'`).
 
 ## Feature requests and bug reports
 
@@ -157,11 +146,16 @@ If you discover a bug, please [raise an issue] with a minimal reproducible examp
 
 - [cgordberg/bump-dependencies](https://github.com/cgoldberg/bump-dependencies) — updates dependency specifiers in `pyproject.toml` to latest compatible versions.
 
-- [hmaarrfk/nep29](https://github.com/hmaarrfk/nep29) — calculator tools for [NEP 29](https://github.com/hmaarrfk/nep29), a precursor to SPEC 0. `nep29` can be used to check the results of `bump-minimum-dependencies`, as in the following example (if uv is installed):
+- [hmaarrfk/nep29](https://github.com/hmaarrfk/nep29) — calculator tools for [NEP 29], a precursor to SPEC 0. `nep29` can be used to check the results of `bump-minimum-dependencies`, as in the following example (if uv is installed):
 
   ```shell
   uvx --python=3.14 --with=setuptools nep29 --n_minor=1 --n_months=12 scipy
   ```
 
+
+[dep-logic]: https://github.com/pdm-project/dep-logic
+[nep 29]: https://github.com/hmaarrfk/nep29
 [raise an issue]: https://github.com/namurphy/bump-minimum-dependencies/issues/new
+[resolution strategy]: https://docs.astral.sh/uv/concepts/resolution/#resolution-strategy
 [spec 0]: https://scientific-python.org/specs/spec-0000
+[version specifiers]: https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ Inspired by [SPEC 0]. 🧪
 ## Motivation
 
 Determining the minimum requirements of a Python package requires balancing competing tradeoffs.
-Support windows that are too long increase the maintenance burden, prevent developers from using new features and assuming bugfixes, and lead to more complicated code to account for various contingencies.
-Support windows that are too brief increase the risk of dependency conflicts.
-The maintenance burden is further increased when developers repeatedly discuss when to drop dependencies.
+Lengthly support windows increase maintenance burden, prevent developers from using new features and assuming bugfixes, and lead to more complicated code.
+Short support windows increase the risk of dependency conflicts.
 Automatically bumping minimum requirements in a predictable way saves time and balances these tradeoffs.
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "uv-build>=0.12.3,<0.13" ]
 
 [project]
 name = "bump-minimum-dependencies"
-version = "0.3.1"
+version = "0.4.0"
 description = "Command line tool to bump minimum dependencies in pyproject.toml"
 readme = "README.md"
 license-files = [ "LICENSE" ]

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -4,6 +4,8 @@ __all__ = [
     "BumpMinimumDependencies",
     "BumpPackage",
     "combine_requirements",
+    "DEFAULT_COOLDOWN_MONTHS",
+    "DEFAULT_DROP_MONTHS",
     "get_new_requirement_for_package",
     "requirement_already_included",
 ]
@@ -35,6 +37,9 @@ import math
 import subprocess
 import functools
 
+DEFAULT_DROP_MONTHS = 24
+DEFAULT_COOLDOWN_MONTHS = 18
+
 DAYS_PER_MONTH = 30.436875
 
 
@@ -61,9 +66,7 @@ class BumpPackage:
         will be at least cooldown_months old.
     """
 
-    def __init__(
-        self, name: str, drop_months: float, cooldown_months: float, bump_micro: bool
-    ):
+    def __init__(self, name: str, drop_months: float, cooldown_months: float):
         self.name = name
         self.today: datetime.date = datetime.datetime.now().date()
         self.versions_to_release_dates: dict[Version, datetime.date] = (
@@ -75,7 +78,6 @@ class BumpPackage:
         )
         self.drop_months = drop_months
         self.cooldown_months = cooldown_months
-        self.bump_micro = bump_micro
 
     @functools.cached_property
     def drop_date(self) -> datetime.date:
@@ -255,25 +257,24 @@ class BumpPackage:
             ),
         )
 
-        if self.bump_micro:
-            if new_minimum_version < self.last_release_before_drop_date:
-                older_release_date = self.versions_to_release_dates[
-                    new_minimum_version
-                ].isoformat()
-                newer_release_date = self.versions_to_release_dates[
-                    self.last_release_before_drop_date
-                ].isoformat()
+        if new_minimum_version < self.last_release_before_drop_date:
+            older_release_date = self.versions_to_release_dates[
+                new_minimum_version
+            ].isoformat()
+            newer_release_date = self.versions_to_release_dates[
+                self.last_release_before_drop_date
+            ].isoformat()
 
-                logger.info(
-                    f"{package_prefix(self.name)} "
-                    f"Bumping micro version from "
-                    f"{str(new_minimum_version)} "
-                    f"({older_release_date}) "
-                    f"to {str(self.last_release_before_drop_date)} "
-                    f"({newer_release_date})."
-                )
+            logger.info(
+                f"{package_prefix(self.name)} "
+                f"Bumping micro version from "
+                f"{str(new_minimum_version)} "
+                f"({older_release_date}) "
+                f"to {str(self.last_release_before_drop_date)} "
+                f"({newer_release_date})."
+            )
 
-                new_minimum_version = self.last_release_before_drop_date
+            new_minimum_version = self.last_release_before_drop_date
 
         release_date: datetime.date = self.versions_to_release_dates[
             new_minimum_version
@@ -332,14 +333,12 @@ def get_new_requirement_for_package(
     requirement: Requirement,
     drop_months: float | int,
     cooldown_months: float | int,
-    bump_micro: bool,
 ) -> str | None:
     """Combine the time-based requirement with the original requirement."""
     package = BumpPackage(
         requirement.name,
         drop_months=drop_months,
         cooldown_months=cooldown_months,
-        bump_micro=bump_micro,
     )
     logger.debug(
         f"{package_prefix(requirement.name)} Original specifier: {str(requirement.specifier)}",
@@ -367,7 +366,7 @@ def get_new_requirement_for_package(
 
 
 class BumpMinimumDependencies:
-    """
+    f"""
     Bump the minimum core dependencies in `pyproject.toml`.
 
     Parameters
@@ -381,11 +380,11 @@ class BumpMinimumDependencies:
     all_groups: bool, keyword-only, default: False
         Update all dependency groups.
 
-    cooldown_months: int, keyword-only, default: 18
+    cooldown_months: int, keyword-only, default: {DEFAULT_COOLDOWN_MONTHS}
         The number of months since a package's release before it can
         become the minimum version, when possible.
 
-    drop_months: int, keyword-only, default: 24
+    drop_months: int, keyword-only, default: {DEFAULT_DROP_MONTHS}
         The preferred number of months after which a minor release is
         no longer supported.
 
@@ -422,7 +421,6 @@ class BumpMinimumDependencies:
         only_package: tuple[str, ...] | list[str] = (),
         skip_group: tuple[str, ...] | list[str] = (),
         skip_extra: tuple[str, ...] | list[str] = (),
-        bump_micro: bool = False,
         verbosity: Literal[
             "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"
         ] = "WARNING",
@@ -431,18 +429,21 @@ class BumpMinimumDependencies:
 
         if cooldown_months > drop_months:
             # issue a warning when cooldown_months ≠ the default value
-            if cooldown_months != 12:
+            if cooldown_months != DEFAULT_COOLDOWN_MONTHS:
                 msg = f"Reducing cooldown_months to {drop_months} to equal drop_months."
                 logger.warning(msg, extra={"markup": True})
 
             cooldown_months = drop_months
 
         self.pyproject_file: str | pathlib.Path = pyproject_file
+
         self.update_all_optionals: bool = all_extras
         self.update_all_dependency_groups: bool = all_groups
         self.skip_core_requirements: bool = skip_core
+
         self.cooldown_months: float = cooldown_months
         self.drop_months: float = drop_months
+
         self.optional_categories: set[str] = {category.lower() for category in extra}
         self.dependency_groups: set[str] = {
             dependency_group.lower() for dependency_group in group
@@ -453,7 +454,6 @@ class BumpMinimumDependencies:
         self.only_update_these_packages: set[str] = {
             package.lower() for package in only_package
         }
-        self.bump_micro = bump_micro
 
         try:
             self.pyproject: PyProject = PyProject(pyproject_file)
@@ -603,7 +603,6 @@ class BumpMinimumDependencies:
                     requirement=requirement,
                     drop_months=self.drop_months,
                     cooldown_months=self.cooldown_months,
-                    bump_micro=self.bump_micro,
                 )
             except NoReleasesError:
                 logger.warning(

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -1,10 +1,5 @@
 """Core functionality for bumping dependencies."""
 
-# Definitions:
-#  - group ≡ a dependency group
-#  - extra ≡ an optional dependencies category
-#  - optional dependency ≡ a dependency in an extra
-
 __all__ = [
     "BumpMinimumDependencies",
     "BumpPackage",
@@ -55,21 +50,51 @@ class BumpPackage:
     ----------
     name : str
         The name of the package.
+
+    drop_months: float
+        The expected support window for dependencies. All minor
+        releases in the last drop_months will be supported.
+
+    cooldown_months: float
+        The number of months to use as a grace period for minor
+        releases.  If possible, the oldest supported minor release
+        will be at least cooldown_months old.
     """
 
-    def __init__(self, name: str):
+    def __init__(
+        self, name: str, drop_months: float, cooldown_months: float, bump_micro: bool
+    ):
         self.name = name
         self.today: datetime.date = datetime.datetime.now().date()
         self.versions_to_release_dates: dict[Version, datetime.date] = (
             utils.make_version_to_release_date_dict(
-                self.response,
+                self.response_from_pypi,
                 skip_yanked=True,
                 skip_prerelease=True,
             )
         )
+        self.drop_months = drop_months
+        self.cooldown_months = cooldown_months
+        self.bump_micro = bump_micro
 
     @functools.cached_property
-    def response(self) -> dict:
+    def drop_date(self) -> datetime.date:
+        """The date drop_months before today."""
+        support_window = datetime.timedelta(
+            days=math.ceil(self.drop_months * DAYS_PER_MONTH)
+        )
+        return self.today - support_window
+
+    @functools.cached_property
+    def cooldown_date(self) -> datetime.date:
+        """The date cooldown_months before today."""
+        cooldown_period = datetime.timedelta(
+            days=math.ceil(self.cooldown_months * DAYS_PER_MONTH)
+        )
+        return self.today - cooldown_period
+
+    @functools.cached_property
+    def response_from_pypi(self) -> dict:
         """Representation of JSON file from PyPI."""
         return requests.get(
             url=f"https://pypi.org/simple/{self.name}",
@@ -159,88 +184,96 @@ class BumpPackage:
 
         return sorted(minor_releases)
 
-    def oldest_supported_release(
-        self,
-        drop_months: float,
-        cooldown_months: float,
-    ) -> str:
-        """
-        Get the oldest supported release of the package.
+    @functools.cached_property
+    def last_release_before_drop_date(self) -> Version:
+        releases_before_drop_date: list[Version] = [
+            version
+            for version, release_date in self.versions_to_release_dates.items()
+            if release_date <= self.drop_date
+        ]
 
-        Parameters
-        ----------
-        drop_months: float
-            The expected support window for dependencies. All minor
-            releases in the last ``drop_months`` will be supported.
+        return max(releases_before_drop_date, default=Version("0"))
 
-        cooldown_months: float
-            The number of months to use as a grace period for minor
-            releases.  If possible, the oldest supported minor release
-            will be at least `cooldown_months` old.
-        """
+    def oldest_supported_release(self) -> str:
+        """Get the oldest supported release of the package."""
 
         if not self.minor_releases:
             msg = f"[{self.name}] No minor releases identified."
             raise NoReleasesError(msg)
 
-        support_window = datetime.timedelta(
-            days=math.ceil(drop_months * DAYS_PER_MONTH)
-        )
-        cooldown_period = datetime.timedelta(
-            days=math.ceil(cooldown_months * DAYS_PER_MONTH)
-        )
+        supported_minor_releases_before_cooldown: list[Version] = []
+        minor_releases_before_drop_date: list[Version] = []
 
-        drop_date: datetime.date = self.today - support_window
-        cooldown_date: datetime.date = self.today - cooldown_period
-
-        supported_releases_before_cooldown: list[Version] = []
-        releases_before_drop_date: list[Version] = []
-
-        for release in self.minor_releases:
+        for minor_release in self.minor_releases:
             try:
-                release_date: datetime.date = self.versions_to_release_dates[release]
+                release_date: datetime.date = self.versions_to_release_dates[
+                    minor_release
+                ]
             except KeyError:
                 logger.debug(
                     f"{package_prefix(self.name)} "
-                    f"Version {str(release)} is not in the "
+                    f"Version {str(minor_release)} is not in the "
                     f"mapping from versions to release dates, possibly due "
                     f"to non-standard versioning or that the release was "
                     f"yanked or a prerelease. Continuing.",
                 )
                 continue
 
-            if drop_date <= release_date < cooldown_date:
-                supported_releases_before_cooldown.append(release)
-            elif release_date < drop_date:
-                releases_before_drop_date.append(release)
+            if self.drop_date <= release_date < self.cooldown_date:
+                supported_minor_releases_before_cooldown.append(minor_release)
+            elif release_date < self.drop_date:
+                minor_releases_before_drop_date.append(minor_release)
 
-        if not supported_releases_before_cooldown:
+        if not supported_minor_releases_before_cooldown:
             logger.debug(
                 f"{package_prefix(self.name)} "
                 f"No supported releases prior to cooldown. "
-                f"({cooldown_date.isoformat()})",
+                f"({self.cooldown_date.isoformat()})",
             )
 
-        if not releases_before_drop_date:
+        if not minor_releases_before_drop_date:
             logger.debug(
                 f"{package_prefix(self.name)} "
-                f"No releases prior to drop date ({drop_date.isoformat()}).",
+                f"No releases prior to drop date ({self.drop_date.isoformat()}).",
             )
 
         # when a package's first release is during the cooldown period
-        if not supported_releases_before_cooldown and not releases_before_drop_date:
+        if (
+            not supported_minor_releases_before_cooldown
+            and not minor_releases_before_drop_date
+        ):
             logger.debug(
                 f"{package_prefix(self.name)} First release is during the cooldown period.",
             )
             return utils.normalize_requirement_string(min(self.released_versions))
 
         new_minimum_version = min(
-            supported_releases_before_cooldown,
+            supported_minor_releases_before_cooldown,
             default=max(
-                releases_before_drop_date,
+                minor_releases_before_drop_date,
                 default=min(self.minor_releases),
             ),
         )
+
+        if self.bump_micro:
+            if new_minimum_version < self.last_release_before_drop_date:
+                older_release_date = self.versions_to_release_dates[
+                    new_minimum_version
+                ].isoformat()
+                newer_release_date = self.versions_to_release_dates[
+                    self.last_release_before_drop_date
+                ].isoformat()
+
+                logger.info(
+                    f"{package_prefix(self.name)} "
+                    f"Bumping micro version from "
+                    f"{str(new_minimum_version)} "
+                    f"({older_release_date}) "
+                    f"to {str(self.last_release_before_drop_date)} "
+                    f"({newer_release_date})."
+                )
+
+                new_minimum_version = self.last_release_before_drop_date
 
         release_date: datetime.date = self.versions_to_release_dates[
             new_minimum_version
@@ -299,16 +332,19 @@ def get_new_requirement_for_package(
     requirement: Requirement,
     drop_months: float | int,
     cooldown_months: float | int,
+    bump_micro: bool,
 ) -> str | None:
     """Combine the time-based requirement with the original requirement."""
-    package = BumpPackage(requirement.name)
+    package = BumpPackage(
+        requirement.name,
+        drop_months=drop_months,
+        cooldown_months=cooldown_months,
+        bump_micro=bump_micro,
+    )
     logger.debug(
         f"{package_prefix(requirement.name)} Original specifier: {str(requirement.specifier)}",
     )
-    calculated_minimum_version = package.oldest_supported_release(
-        drop_months=drop_months,
-        cooldown_months=cooldown_months,
-    )
+    calculated_minimum_version = package.oldest_supported_release()
     time_based_requirement = f">={calculated_minimum_version}"
     logger.debug(
         f"{package_prefix(requirement.name)} Time-based specifier: {time_based_requirement}",
@@ -386,6 +422,7 @@ class BumpMinimumDependencies:
         only_package: tuple[str, ...] | list[str] = (),
         skip_group: tuple[str, ...] | list[str] = (),
         skip_extra: tuple[str, ...] | list[str] = (),
+        bump_micro: bool = False,
         verbosity: Literal[
             "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"
         ] = "WARNING",
@@ -416,6 +453,7 @@ class BumpMinimumDependencies:
         self.only_update_these_packages: set[str] = {
             package.lower() for package in only_package
         }
+        self.bump_micro = bump_micro
 
         try:
             self.pyproject: PyProject = PyProject(pyproject_file)
@@ -565,6 +603,7 @@ class BumpMinimumDependencies:
                     requirement=requirement,
                     drop_months=self.drop_months,
                     cooldown_months=self.cooldown_months,
+                    bump_micro=self.bump_micro,
                 )
             except NoReleasesError:
                 logger.warning(

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -79,6 +79,11 @@ class BumpPackage:
         self.drop_months = drop_months
         self.cooldown_months = cooldown_months
 
+    @property
+    def prefix(self) -> str:
+        """The package prefix for log messages."""
+        return package_prefix(self.name)
+
     @functools.cached_property
     def drop_date(self) -> datetime.date:
         """The date drop_months before today."""
@@ -132,7 +137,7 @@ class BumpPackage:
             if (epoch, major, minor) not in epoch_major_minor_to_set_of_micro:
                 if version.post is not None:
                     logger.info(
-                        f"{package_prefix(self.name)} Skipping post release: {str(version)}",
+                        f"{self.prefix} Skipping post release: {str(version)}",
                     )
                     continue
                 epoch_major_minor_to_set_of_micro[(epoch, major, minor)] = {micro}
@@ -157,7 +162,7 @@ class BumpPackage:
                 minor_releases.append(version)
             else:
                 logger.debug(
-                    f"{package_prefix(self.name)} Reconstructed version {version} not found "
+                    f"{self.prefix} Reconstructed version {version} not found "
                     f"in released versions. Skipping.",
                 )
 
@@ -184,32 +189,31 @@ class BumpPackage:
         if minimum_minor_version >= minimum_micro_version:
             return minimum_minor_version
 
-        if minimum_minor_version.major >= 2:
-            return minimum_minor_version
-
         def log_switch(minor_version, micro_version, reason):
             minor_date = self.versions_to_release_dates[minor_version].isoformat()
             micro_date = self.versions_to_release_dates[micro_version].isoformat()
             logger.warning(
-                         f"{package_prefix(self.name)} "
-                         f"Bumping version from "
-                         f"{str(minor_version)} ({minor_date}) "
-                         f"to {str(micro_version)} ({micro_date}) {reason}."
+                f"{self.prefix} Bumping version from "
+                f"{str(minor_version)} ({minor_date}) to "
+                f"{str(micro_version)} ({micro_date}) {reason}."
             )
 
-        if minimum_minor_version.major == 0 and minimum_minor_version.minor < 5:
-            log_switch(
-                minor_version=minimum_minor_version,
-                micro_version=minimum_micro_version,
-                reason=f"due to pre-0.5 release",
-            )
-            return minimum_micro_version
-
-        if minimum_micro_version.micro >= 15:
+        if minimum_micro_version.micro >= 25:
             log_switch(
                 minor_version=minimum_minor_version,
                 micro_version=minimum_micro_version,
                 reason="because of large number of micro releases",
+            )
+            return minimum_micro_version
+
+        if minimum_minor_version.major >= 1 or minimum_minor_version.epoch > 0:
+            return minimum_minor_version
+
+        if minimum_minor_version.major < 1:
+            log_switch(
+                minor_version=minimum_minor_version,
+                micro_version=minimum_micro_version,
+                reason="due to pre-1.0 release number",
             )
             return minimum_micro_version
 
@@ -232,11 +236,11 @@ class BumpPackage:
                 ]
             except KeyError:
                 logger.debug(
-                    f"{package_prefix(self.name)} "
-                    f"Version {str(minor_release)} is not in the "
-                    f"mapping from versions to release dates, possibly due "
-                    f"to non-standard versioning or that the release was "
-                    f"yanked or a prerelease. Continuing.",
+                    f"{self.prefix} Version {str(minor_release)} "
+                    f"is not in the mapping from versions to release "
+                    f"dates, possibly due to non-standard versioning or "
+                    f"that the release was yanked or a prerelease. "
+                    f"Continuing.",
                 )
                 continue
 
@@ -247,14 +251,14 @@ class BumpPackage:
 
         if not supported_minor_releases_before_cooldown:
             logger.debug(
-                f"{package_prefix(self.name)} "
+                f"{self.prefix} "
                 f"No supported releases prior to cooldown. "
                 f"({self.cooldown_date.isoformat()})",
             )
 
         if not minor_releases_before_drop_date:
             logger.debug(
-                f"{package_prefix(self.name)} "
+                f"{self.prefix} "
                 f"No releases prior to drop date ({self.drop_date.isoformat()}).",
             )
 
@@ -264,7 +268,7 @@ class BumpPackage:
             and not minor_releases_before_drop_date
         ):
             logger.debug(
-                f"{package_prefix(self.name)} First release is during the cooldown period.",
+                f"{self.prefix} First release is during the cooldown period.",
             )
             return utils.normalize_requirement_string(min(self.released_versions))
 
@@ -279,7 +283,7 @@ class BumpPackage:
         new_minimum_version = self.adjust_micro(new_minimum_version)
 
         logger.info(
-            f"{package_prefix(self.name)} "
+            f"{self.prefix} "
             f"New minimum version: {str(new_minimum_version)} "
             f"({release_date.isoformat()})",
         )

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -139,29 +139,6 @@ class BumpPackage:
             else:
                 epoch_major_minor_to_set_of_micro[(epoch, major, minor)] |= {micro}
 
-        # Packages like pyright have used versioning schemes that
-        # prioritize bumping the micro/patch version number rather than
-        # the minor version number, which is inconsistent with the
-        # versioning practices assumed by bump-minimum-dependencies.
-        if len(epoch_major_minor_to_set_of_micro) <= 5:
-            for x in epoch_major_minor_to_set_of_micro:
-                number_of_micros = len(epoch_major_minor_to_set_of_micro[x])
-                if number_of_micros >= 25:
-                    major_minor = f"{x[1]}.{x[2]}"
-                    first_patch = (
-                        f"{major_minor}.{min(epoch_major_minor_to_set_of_micro[x])}"
-                    )
-                    last_patch = (
-                        f"{major_minor}.{max(epoch_major_minor_to_set_of_micro[x])}"
-                    )
-                    logger.warning(
-                        f"{self.name} has {number_of_micros} identified releases "
-                        f"between {first_patch} and {last_patch}, suggesting a "
-                        f"versioning practice of bumping micro rather than minor "
-                        f"release numbers. Consider adjusting "
-                        f"the minimum allowed version of {self.name} manually.",
-                    )
-
         return epoch_major_minor_to_set_of_micro
 
     @functools.cached_property
@@ -195,6 +172,48 @@ class BumpPackage:
         ]
 
         return max(releases_before_drop_date, default=Version("0"))
+
+    def adjust_micro(self, minimum_minor_version: Version) -> Version:
+        """
+        Drop older micro releases when the major/minor release numbers
+        are too low, in particular when there have been a large number
+        of micro releases.
+        """
+        minimum_micro_version = self.last_release_before_drop_date
+
+        if minimum_minor_version >= minimum_micro_version:
+            return minimum_minor_version
+
+        if minimum_minor_version.major >= 2:
+            return minimum_minor_version
+
+        def log_switch(minor_version, micro_version, reason):
+            minor_date = self.versions_to_release_dates[minor_version].isoformat()
+            micro_date = self.versions_to_release_dates[micro_version].isoformat()
+            logger.warning(
+                         f"{package_prefix(self.name)} "
+                         f"Bumping version from "
+                         f"{str(minor_version)} ({minor_date}) "
+                         f"to {str(micro_version)} ({micro_date}) {reason}."
+            )
+
+        if minimum_minor_version.major == 0 and minimum_minor_version.minor < 5:
+            log_switch(
+                minor_version=minimum_minor_version,
+                micro_version=minimum_micro_version,
+                reason=f"due to pre-0.5 release",
+            )
+            return minimum_micro_version
+
+        if minimum_micro_version.micro >= 15:
+            log_switch(
+                minor_version=minimum_minor_version,
+                micro_version=minimum_micro_version,
+                reason="because of large number of micro releases",
+            )
+            return minimum_micro_version
+
+        return minimum_minor_version
 
     def oldest_supported_release(self) -> str:
         """Get the oldest supported release of the package."""
@@ -257,28 +276,7 @@ class BumpPackage:
             ),
         )
 
-        if new_minimum_version < self.last_release_before_drop_date:
-            older_release_date = self.versions_to_release_dates[
-                new_minimum_version
-            ].isoformat()
-            newer_release_date = self.versions_to_release_dates[
-                self.last_release_before_drop_date
-            ].isoformat()
-
-            logger.info(
-                f"{package_prefix(self.name)} "
-                f"Bumping micro version from "
-                f"{str(new_minimum_version)} "
-                f"({older_release_date}) "
-                f"to {str(self.last_release_before_drop_date)} "
-                f"({newer_release_date})."
-            )
-
-            new_minimum_version = self.last_release_before_drop_date
-
-        release_date: datetime.date = self.versions_to_release_dates[
-            new_minimum_version
-        ]
+        new_minimum_version = self.adjust_micro(new_minimum_version)
 
         logger.info(
             f"{package_prefix(self.name)} "

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -8,12 +8,6 @@ from . import bump
 
 from typing import Literal
 
-DEFAULT_DROP_MONTHS = 24
-DEFAULT_COOLDOWN_MONTHS = 18
-DEFAULT_ALL_EXTRAS = False
-DEFAULT_ALL_GROUPS = False
-DEFAULT_SKIP_CORE = False
-
 
 @click.command(
     "bump-minimum-dependencies",
@@ -33,13 +27,13 @@ DEFAULT_SKIP_CORE = False
 )
 @click.option(
     "--drop-months",
-    default=DEFAULT_DROP_MONTHS,
+    default=bump.DEFAULT_DROP_MONTHS,
     type=click.FloatRange(min=0, max_open=True),
     help=("Drop minor releases older than this many months ago."),
 )
 @click.option(
     "--cooldown-months",
-    default=DEFAULT_COOLDOWN_MONTHS,
+    default=bump.DEFAULT_COOLDOWN_MONTHS,
     type=click.FloatRange(min=0, max_open=True),
     help=(
         "Keep at least one release this old, not to exceed drop-months, if possible."
@@ -109,14 +103,6 @@ DEFAULT_SKIP_CORE = False
     help="Do not update core project dependencies.",
 )
 @click.option(
-    "--bump-micro",
-    default=False,
-    is_flag=True,
-    help="Drop support for all but the highest micro release before "
-    "the drop date. Useful for packages that perform "
-    "micro releases in place of minor releases.",
-)
-@click.option(
     "--verbosity",
     default="WARNING",
     type=click.Choice(
@@ -138,7 +124,6 @@ def main(
     only_package: tuple[str, ...] | list[str],
     skip_group: tuple[str, ...] | list[str],
     skip_extra: tuple[str, ...] | list[str],
-    bump_micro: bool,
     verbosity: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"],
 ) -> None:
     """
@@ -173,7 +158,6 @@ def main(
         verbosity=verbosity,
         skip_group=skip_group,
         skip_extra=skip_extra,
-        bump_micro=bump_micro,
     )
 
     bump_minimum_dependencies.run()

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -109,6 +109,14 @@ DEFAULT_SKIP_CORE = False
     help="Do not update core project dependencies.",
 )
 @click.option(
+    "--bump-micro",
+    default=False,
+    is_flag=True,
+    help="Drop support for all but the highest micro release before "
+    "the drop date. Useful for packages that perform "
+    "micro releases in place of minor releases.",
+)
+@click.option(
     "--verbosity",
     default="WARNING",
     type=click.Choice(
@@ -130,6 +138,7 @@ def main(
     only_package: tuple[str, ...] | list[str],
     skip_group: tuple[str, ...] | list[str],
     skip_extra: tuple[str, ...] | list[str],
+    bump_micro: bool,
     verbosity: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"],
 ) -> None:
     """
@@ -164,6 +173,7 @@ def main(
         verbosity=verbosity,
         skip_group=skip_group,
         skip_extra=skip_extra,
+        bump_micro=bump_micro,
     )
 
     bump_minimum_dependencies.run()

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -127,18 +127,17 @@ def main(
     verbosity: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"],
 ) -> None:
     """
-    Bump the minimum allowed minor versions of package dependencies.
+    Bump minimum allowed versions of package dependencies in pyproject.toml.
 
     This tool updates pyproject.toml via `uv add --frozen` to drop
     support for minor versions of package dependencies based on the time
     since the minor version was first released, where package versions
-    may be given by `<MAJOR>.<MINOR>` or `<MAJOR>.<MINOR>.<PATCH>`.
-    Additional constraints such as upper limits are preserved.
+    may be given by `<MAJOR>.<MINOR>` or `<MAJOR>.<MINOR>.<MICRO>`.
 
-    For example, if version `3.4.0` of a package dependency was released
-    25 months ago and version `3.5.0` was released 23 months ago,
-    running `bump-minimum-dependencies` will update the requirement from
-    `>=3.4.0` to `>=3.5.0`.
+    When a `<MAJOR>.<MINOR>` release has numerous micro releases or for
+    pre-1.0 releases, `<MICRO>` might also be bumped to the last release
+    prior to the drop date. Additional constraints such as upper limits
+    are preserved.
 
     Requirements with markers or that cannot be updated will be skipped
     with a warning.

--- a/tests/data/base_case/pyproject.expected.toml
+++ b/tests/data/base_case/pyproject.expected.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
   "astropy>=6",
-  "docutils>=0.20,<2",
+  "docutils>=0.20.1,<2",  # bump micro version
   "heliopy>=1,<2",
   "nose~=1.0.0",
   "nox>=2025.10.16",

--- a/tests/data/base_case/pyproject.toml
+++ b/tests/data/base_case/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
   "astropy",
-  "docutils!=0.19,<2",
+  "docutils!=0.19,<2",  # bump micro version
   "heliopy<2",
   "nose~=1.0.0",
   "nox>=2025.10.16",

--- a/tests/data/bump_all_dependency_groups/pyproject.expected.toml
+++ b/tests/data/bump_all_dependency_groups/pyproject.expected.toml
@@ -13,7 +13,7 @@ astropy = [
   "astropy>=6",
 ]
 docutils = [
-  "docutils>=0.20,<2",
+  "docutils>=0.20.1,<2",  # bump micro version
 ]
 heliopy = [
   "heliopy>=1,<2",

--- a/tests/data/bump_all_dependency_groups/pyproject.toml
+++ b/tests/data/bump_all_dependency_groups/pyproject.toml
@@ -13,7 +13,7 @@ astropy = [
   "astropy",
 ]
 docutils = [
-  "docutils!=0.19,<2",
+  "docutils!=0.19,<2",  # bump micro version
 ]
 heliopy = [
   "heliopy<2",

--- a/tests/data/bump_pyright/pyproject.expected.toml
+++ b/tests/data/bump_pyright/pyproject.expected.toml
@@ -3,5 +3,5 @@ name = "bump-pyright"
 version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
-    "pyright>=1.1.225",  # 1.1.224 was yanked and followed by 1.1.224.post0 and 1.1.224.post1
+    "pyright>=1.1.403",  # 1.1.224 was yanked and followed by 1.1.224.post0 and 1.1.224.post1; bump micro
 ]

--- a/tests/data/bump_pyright/pyproject.toml
+++ b/tests/data/bump_pyright/pyproject.toml
@@ -3,5 +3,5 @@ name = "bump-pyright"
 version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
-    "pyright>0.0.1",  # 1.1.224 was yanked and followed by 1.1.224.post0 and 1.1.224.post1
+    "pyright>0.0.1",  # 1.1.224 was yanked and followed by 1.1.224.post0 and 1.1.224.post1; bump micro
 ]

--- a/tests/data/pydantic/pyproject.expected.toml
+++ b/tests/data/pydantic/pyproject.expected.toml
@@ -41,7 +41,7 @@ dev = [
     "pytest>=9",
     "pytest-mock>=3.15",
     "pytest-pretty>=1.3",
-    "pytest-examples>=0.0.1",
+    "pytest-examples>=0.0.18",  # micro number adjustment
     "faker>=37.6",
     "pytest-benchmark>=5.2",
     "pytest-codspeed>=4.1",
@@ -76,7 +76,7 @@ docs-upload = [
 ]
 linting = [
     "ruff>=0.13",
-    "pyright>=1.1.225",
+    "pyright>=1.1.403",  # micro number adjustment
 ]
 testing-extra = [
     "cloudpickle>=3.1",
@@ -88,7 +88,7 @@ testing-extra = [
 ]
 typechecking = [
     "mypy>=1.18.1",
-    "pyright>=1.1.225",
+    "pyright>=1.1.403",  # micro number adjustment
     "pyrefly>=0.29",
     "pydantic-settings>=2.11",
 ]

--- a/tests/data/pydantic/pyproject.expected.toml
+++ b/tests/data/pydantic/pyproject.expected.toml
@@ -81,8 +81,8 @@ linting = [
 testing-extra = [
     "cloudpickle>=3.1",
     "ansi2html>=1.9.1",
-    "devtools>=0.12",
-    "sqlalchemy>=2",
+    "devtools>=0.12.2",  # bump micro version
+    "sqlalchemy>=2.0.43",  # bump micro version
     'pytest-memray; platform_python_implementation == "CPython" and platform_system != "Windows" and python_version < "3.15"',
     'memray; platform_python_implementation == "CPython" and platform_system != "Windows" and python_version < "3.15"',
 ]

--- a/tests/data/pydantic/pyproject.toml
+++ b/tests/data/pydantic/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     'pytest',
     'pytest-mock',
     'pytest-pretty',
-    'pytest-examples',
+    'pytest-examples',  # micro number adjustment
     'faker',
     'pytest-benchmark',
     'pytest-codspeed',
@@ -76,7 +76,7 @@ docs-upload = [
 ]
 linting = [
     'ruff',
-    'pyright',
+    'pyright',  # micro number adjustment
 ]
 testing-extra = [
     'cloudpickle',
@@ -88,7 +88,7 @@ testing-extra = [
 ]
 typechecking = [
     'mypy',
-    'pyright',
+    'pyright',  # micro number adjustment
     'pyrefly',
     'pydantic-settings',
 ]

--- a/tests/data/pydantic/pyproject.toml
+++ b/tests/data/pydantic/pyproject.toml
@@ -81,8 +81,8 @@ linting = [
 testing-extra = [
     'cloudpickle',
     'ansi2html',
-    'devtools',
-    'sqlalchemy',
+    'devtools',  # bump micro version
+    'sqlalchemy',  # bump micro version
     'pytest-memray; platform_python_implementation == "CPython" and platform_system != "Windows" and python_version < "3.15"',
     'memray; platform_python_implementation == "CPython" and platform_system != "Windows" and python_version < "3.15"',
 ]

--- a/tests/data/scipy/pyproject.expected.toml
+++ b/tests/data/scipy/pyproject.expected.toml
@@ -164,8 +164,8 @@ bench = [
 doc = [
     "sphinx>=8.2.0,<8.3.0",
     "intersphinx-registry>=0.2510.5",
-    "pydata-sphinx-theme>=0.16",
-    "sphinx-copybutton>=0.5",
+    "pydata-sphinx-theme>=0.16.1",  # bump micro version
+    "sphinx-copybutton>=0.5.2",  # bump micro version
     "sphinx-design>=0.7",
     "matplotlib>=3.10",
     "numpydoc>=1.10",
@@ -201,7 +201,7 @@ typecheck = [
     # "scikit-umfpack",
     "sphinx>=9",
     "sympy>=1.14",
-    "uarray>=0.9.1",
+    "uarray>=0.9.2",  # bump micro version
 ]
 
 lint = [

--- a/tests/data/scipy/pyproject.expected.toml
+++ b/tests/data/scipy/pyproject.expected.toml
@@ -129,7 +129,7 @@ test-docs = [
 test-array-types = [
     { include-group = "test-core" },
     "array-api-strict>=2.4",
-    "marray>=0.0.1",
+    "marray>=0.0.11",  # micro number adjustment
     # for PyPI: 'sparse; sys_platform != "win32" or platform_machine != "ARM64"'
     "sparse>=0.17",
 ]

--- a/tests/data/scipy/pyproject.toml
+++ b/tests/data/scipy/pyproject.toml
@@ -129,7 +129,7 @@ test-docs = [
 test-array-types = [
     { include-group = "test-core" },
     "array-api-strict>=2.3.1",
-    "marray",
+    "marray",  # micro number adjustment
     # for PyPI: 'sparse; sys_platform != "win32" or platform_machine != "ARM64"'
     "sparse",
 ]

--- a/tests/data/scipy/pyproject.toml
+++ b/tests/data/scipy/pyproject.toml
@@ -164,8 +164,8 @@ bench = [
 doc = [
     "sphinx>=8.2.0,<8.3.0",
     "intersphinx_registry",
-    "pydata-sphinx-theme>=0.15.2",
-    "sphinx-copybutton",
+    "pydata-sphinx-theme>=0.15.2",  # bump micro version
+    "sphinx-copybutton",  # bump micro version
     "sphinx-design>=0.4.0",
     "matplotlib>=3.5",
     "numpydoc",
@@ -201,7 +201,7 @@ typecheck = [
     # "scikit-umfpack",
     "sphinx",
     "sympy",
-    "uarray",
+    "uarray",  # bump micro version
 ]
 
 lint = [

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -6,7 +6,7 @@ import pytest
 from pathlib import Path
 
 
-DEFAULT_TEST_VERBOSITY = "DEBUG"
+DEFAULT_TEST_VERBOSITY = "INFO"
 
 
 def get_errmsg_from_file_comparison(

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -274,8 +274,10 @@ def test_bumping_single_package(
     name: str, drop_months: int, cooldown_months: int, expected: str, freezer
 ) -> None:
     freezer.move_to("2026-01-01")
-    package = bump.BumpPackage(name=name)
-    release = package.oldest_supported_release(
-        drop_months=drop_months, cooldown_months=cooldown_months
+    package = bump.BumpPackage(
+        name=name,
+        cooldown_months=cooldown_months,
+        drop_months=drop_months,
     )
+    release = package.oldest_supported_release()
     assert str(release) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "bump-minimum-dependencies"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.7.4"
+version = "21.7.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -489,7 +489,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/dc/a6eb1ddfa7f1e390fa599b078453c97edb3f6f846b34fb4eac3e8ea16401/virtualenv-21.7.4.tar.gz", hash = "sha256:c9d960c95fa458171e58222a5ccab7465298e4b6559977865e627c4719f1e825", size = 5345511, upload-time = "2026-08-10T22:54:33.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/60/fc54e876e34f94dd0cf0185aaecfd4bfa906653f003d9b2fb21428642fca/virtualenv-21.7.5.tar.gz", hash = "sha256:a73c4246fba3c8901ff9717399f466e00eeca5a3834981f1a6ebb4f1e94de2f8", size = 5346743, upload-time = "2026-08-25T05:39:16.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/4c/eb2f52aeeaf30dbd073d315a251a63ae2b8263171ec4428c135140cb0802/virtualenv-21.7.4-py3-none-any.whl", hash = "sha256:376ec93cd6aab3044fa395d7db226db38043b7b5748948044b2a87168525e843", size = 5324444, upload-time = "2026-08-10T22:54:31.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d8/401141bf45637be916c86d325bd821c5838c7eff83294b934cd94e774e4f/virtualenv-21.7.5-py3-none-any.whl", hash = "sha256:e36ca889510ab6cb0b1dca93c59e5431dd4422a3c88f487358d470c90af8c07a", size = 5324697, upload-time = "2026-08-25T05:39:14.229Z" },
 ]


### PR DESCRIPTION
This PR makes it so that `bump-minimum-dependencies` updates micro version number to the last release prior to the drop date in some situations, such as when:

 - The micro release number is very large (for packages that routinely bump micro rather than minor release numbers)
 - The releases are pre-`1.0` (since bugfixes are more likely to be important in early development)

In these cases, the tool logs a warning upon the change.

## Motivation

There are a few packages like prek and pyright that have had a standard practice of bumping the micro release number during regular development instead of the patch release number. In these cases, the original practice of bump-minimum-dependencies and the recommendations of SPEC 0 don't work well, since the minimum allowed version could end up being a minor release many years before the drop date.

## Alternatives

I had considered having a `--bump-micro` option, but decided to make this the default behavior since it's generally desirable.