### PR TITLE
Set the default cooldown period to 1.75 years

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Options:
   --drop-months FLOAT RANGE       Drop minor releases older than this many
                                   months ago.  [default: 24; x>=0]
   --cooldown-months FLOAT RANGE   Keep at least one minor release this old
-                                  when possible.  [default: 18; x>=0]
+                                  when possible.  [default: 21; x>=0]
   --only-package TEXT             Name of a package to update. May be provided
                                   multiple times. When this option is used,
                                   all other packages will be skipped.
@@ -60,7 +60,6 @@ Options:
                                   Logging verbosity level.  [default: WARNING]
   --version                       Show the version and exit.
   --help                          Show this message and exit.
-
 ```
 
 ## Examples

--- a/src/bump_minimum_dependencies/inputs.py
+++ b/src/bump_minimum_dependencies/inputs.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 
 DEFAULT_DROP_MONTHS = 24
-DEFAULT_COOLDOWN_MONTHS = 18
+DEFAULT_COOLDOWN_MONTHS = 21
 
 DAYS_PER_MONTH = 30.44
 
@@ -28,8 +28,8 @@ class Inputs:
         self,
         *,
         pyproject_file: str | Path = Path("pyproject.toml"),
-        drop_months: float = 24,
-        cooldown_months: float = 18,
+        drop_months: float = DEFAULT_DROP_MONTHS,
+        cooldown_months: float = DEFAULT_COOLDOWN_MONTHS,
         all_extras: bool = False,
         all_groups: bool = False,
         skip_core: bool = False,


### PR DESCRIPTION
The purpose of the cooldown period is to ensure that the minimum requirements aren't too new, and that there is a well-defined period of time where we can say "This package will work in a Python environment from $N$ months ago." 

Whilst [SPEC 0] unambiguously sets `--drop-months=24` as the default, SPEC 0 does not mention a cooldown period. Hence it is up to us to figure out a sensible default.  

The default for `--cooldown-months` was recently changed from $12$ to $18$.  This PR increases the default for `--cooldown-months` to $21$. 

My reasoning is:

 - Core scientific Python packages have minor releases once every ∼1–4 months.  Hence it is in the spirit of SPEC 0 to have a cooldown period that is a few months shorter than the drop period.
 - $1.75$ is easier to write than $1.\overline{6}$ or $1.8\overline{3}$; even though these are all rational choices (i.e., $∈$ $ℚ$⁠).

[SPEC 0]: https://scientific-python.org/specs/spec-0000


