### PR TITLE
Enable rules for `ruff check`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -122,7 +122,7 @@ def test_cli(session: nox.Session) -> None:
     )
 
     for x in diff[2:]:
-        print(x.removesuffix("\n"))
+        print(x.removesuffix("\n"))  # ruff:ignore[T201]
 
     session.error(
         "The resulting pyproject.toml does not match pyproject.expected.toml."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,14 +45,13 @@ dev = [
 
 [tool.ruff]
 target-version = "py313"
-namespace-packages = [ ".github/workflows", "docs" ]
+namespace-packages = [ ".github/workflows" ]
 extend-exclude = [
   ".code",
   ".idea",
   "__pycache__",
 ]
 show-fixes = true
-# output-format = "grouped"
 format.line-ending = "lf"
 format.docstring-code-format = true
 # Using an IDE like PyCharm with a ruff plugin will make rule names appear as inlay hints
@@ -184,7 +183,6 @@ lint.ignore = [
   "W191",    # handled by ruff format
 ]
 lint.extend-per-file-ignores."__init__.py" = [ "D104", "E402", "F401", "F402", "F403" ]  # ignore import errors
-lint.extend-per-file-ignores."docs/conf.py" = [ "D100", "D103", "E402", "EXE001", "EXE005", "F401" ]
 lint.extend-per-file-ignores."tests/**/__init__.py" = [ "D104" ]
 lint.extend-per-file-ignores."tests/**/test_*.py" = [
   "DOC201",
@@ -194,31 +192,11 @@ lint.extend-per-file-ignores."tests/**/test_*.py" = [
   "S101",
   "SLF001",
 ]
-lint.flake8-import-conventions.aliases."astropy.constants" = "const"
-lint.flake8-import-conventions.aliases."astropy.units" = "u"
-lint.flake8-import-conventions.aliases."matplotlib.pyplot" = "plt"
-lint.flake8-import-conventions.aliases.matplotlib = "mpl"
-lint.flake8-import-conventions.aliases.numpy = "np"
-lint.flake8-import-conventions.aliases.pandas = "pd"
 lint.flake8-import-conventions.banned-from = [
   "pytest",
   "warnings",
 ]
 lint.flake8-tidy-imports.ban-relative-imports = "all"
-lint.flake8-tidy-imports.banned-api."typing.Callable".msg = "Deprecated alias. Change to collections.abc.Callable"
-lint.flake8-tidy-imports.banned-api."typing.Collection".msg = "Deprecated alias. Change to collections.abc.Collection"
-lint.flake8-tidy-imports.banned-api."typing.DefaultDict".msg = "Deprecated alias. Change to collections.defaultdict"
-lint.flake8-tidy-imports.banned-api."typing.Dict".msg = "Deprecated alias. Change to dict"
-lint.flake8-tidy-imports.banned-api."typing.Generator".msg = "Deprecated alias. Change to collections.abc.Generator"
-lint.flake8-tidy-imports.banned-api."typing.Iterable".msg = "Deprecated alias. Change to collections.abc.Iterable"
-lint.flake8-tidy-imports.banned-api."typing.Iterator".msg = "Deprecated alias. Change to collections.abc.Iterator"
-lint.flake8-tidy-imports.banned-api."typing.List".msg = "Deprecated alias. Change to list"
-lint.flake8-tidy-imports.banned-api."typing.Mapping".msg = "Deprecated alias. Change to collections.abc.mapping"
-lint.flake8-tidy-imports.banned-api."typing.MutableMapping".msg = "Deprecated alias. Change to collections.abc.MutableMapping"
-lint.flake8-tidy-imports.banned-api."typing.Sequence".msg = "Deprecated alias. Change to collections.abc.Sequence"
-lint.flake8-tidy-imports.banned-api."typing.Set".msg = "Deprecated alias. Change to set"
-lint.flake8-tidy-imports.banned-api."typing.Tuple".msg = "Deprecated alias. Change to tuple"
-lint.flake8-tidy-imports.banned-api."typing.Type".msg = "Deprecated alias. Change to type"
-lint.isort.known-first-party = [ "pyfaradaycup" ]
+lint.isort.known-first-party = [ "bump_minimum_dependencies" ]
 lint.pydocstyle.convention = "numpy"
 lint.pylint.max-positional-args = 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,183 @@ dev = [
   "tomli-w>=1.2",
   "ty>=0.0.69",
 ]
+
+[tool.ruff]
+target-version = "py313"
+namespace-packages = [ ".github/workflows", "docs" ]
+extend-exclude = [
+  ".code",
+  ".idea",
+  "__pycache__",
+]
+show-fixes = true
+# output-format = "grouped"
+format.line-ending = "lf"
+format.docstring-code-format = true
+# Using an IDE like PyCharm with a ruff plugin will make rule names appear as inlay hints
+lint.extend-select = [
+  "A",
+  "ANN",
+  "ARG",
+  "ASYNC",
+  "B",
+  "BLE",
+  "C4",
+  "C90",
+  "COM",
+  "D",
+  "DTZ",
+  "E",
+  "EM",
+  "EXE",
+  "F",
+  "FA",
+  "FBT",
+  "FIX",
+  "FLY",
+  "FURB",
+  "G",
+  "I",
+  "ICN",
+  "INP",
+  "INT",
+  "ISC",
+  "LOG",
+  "N",
+  "NPY",
+  "PD",
+  "PERF",
+  "PGH",
+  "PIE",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "PT",
+  "PTH",
+  "PYI",
+  "Q",
+  "RET",
+  "RSE",
+  "RUF001",
+  "RUF002",
+  "RUF003",
+  "RUF005",
+  "RUF006",
+  "RUF007",
+  "RUF008",
+  "RUF009",
+  "RUF010",
+  "RUF012",
+  "RUF013",
+  "RUF015",
+  "RUF016",
+  "RUF017",
+  "RUF018",
+  "RUF019",
+  "RUF020",
+  "RUF021",
+  "RUF022",
+  "RUF023",
+  "RUF024",
+  "RUF026",
+  "RUF028",
+  "RUF030",
+  "RUF032",
+  "RUF033",
+  "RUF034",
+  "RUF036",
+  "RUF037",
+  "RUF040",
+  "RUF041",
+  "RUF043",
+  "RUF046",
+  "RUF048",
+  "RUF049",
+  "RUF051",
+  "RUF053",
+  "RUF057",
+  "RUF058",
+  "RUF059",
+  "RUF060",
+  "RUF061",
+  "RUF063",
+  "RUF064",
+  "RUF068",
+  "RUF100",
+  "RUF101",
+  "RUF102",
+  "RUF103",
+  "RUF104",
+  "RUF200",
+  "S",
+  "SIM",
+  "SLF",
+  "SLOT",
+  "T10",
+  "T20",
+  "TC",
+  "TD",
+  "TID",
+  "TRY",
+  "UP",
+  "W",
+  "YTT",
+]
+lint.ignore = [
+  "COM812",  # handled by ruff format
+  "COM819",  # adding trailing commas leads to simpler diffs
+  "D200",    # incompatible with multiline short summaries
+  "D203",    # handled by ruff format
+  "D205",    # incompatible with multiline short summaries
+  "D206",    # handled by ruff format
+  "D300",    # handled by ruff format
+  "E111",    # handled by ruff format
+  "E114",    # handled by ruff format
+  "E117",    # handled by ruff format
+  "E501",    # handled by ruff format
+  "Q001",    # handled by ruff format
+  "Q002",    # handled by ruff format
+  "Q003",    # handled by ruff format
+  "Q004",    # handled by ruff format
+  "W191",    # handled by ruff format
+]
+lint.extend-per-file-ignores."__init__.py" = [ "D104", "E402", "F401", "F402", "F403" ]  # ignore import errors
+lint.extend-per-file-ignores."docs/conf.py" = [ "D100", "D103", "E402", "EXE001", "EXE005", "F401" ]
+lint.extend-per-file-ignores."tests/**/__init__.py" = [ "D104" ]
+lint.extend-per-file-ignores."tests/**/test_*.py" = [
+  "DOC201",
+  "DOC501",
+  "INP001",
+  "PLC2701",
+  "S101",
+  "SLF001",
+]
+lint.flake8-import-conventions.aliases."astropy.constants" = "const"
+lint.flake8-import-conventions.aliases."astropy.units" = "u"
+lint.flake8-import-conventions.aliases."matplotlib.pyplot" = "plt"
+lint.flake8-import-conventions.aliases.matplotlib = "mpl"
+lint.flake8-import-conventions.aliases.numpy = "np"
+lint.flake8-import-conventions.aliases.pandas = "pd"
+lint.flake8-import-conventions.banned-from = [
+  "pytest",
+  "warnings",
+]
+lint.flake8-tidy-imports.ban-relative-imports = "all"
+lint.flake8-tidy-imports.banned-api."typing.Callable".msg = "Deprecated alias. Change to collections.abc.Callable"
+lint.flake8-tidy-imports.banned-api."typing.Collection".msg = "Deprecated alias. Change to collections.abc.Collection"
+lint.flake8-tidy-imports.banned-api."typing.DefaultDict".msg = "Deprecated alias. Change to collections.defaultdict"
+lint.flake8-tidy-imports.banned-api."typing.Dict".msg = "Deprecated alias. Change to dict"
+lint.flake8-tidy-imports.banned-api."typing.Generator".msg = "Deprecated alias. Change to collections.abc.Generator"
+lint.flake8-tidy-imports.banned-api."typing.Iterable".msg = "Deprecated alias. Change to collections.abc.Iterable"
+lint.flake8-tidy-imports.banned-api."typing.Iterator".msg = "Deprecated alias. Change to collections.abc.Iterator"
+lint.flake8-tidy-imports.banned-api."typing.List".msg = "Deprecated alias. Change to list"
+lint.flake8-tidy-imports.banned-api."typing.Mapping".msg = "Deprecated alias. Change to collections.abc.mapping"
+lint.flake8-tidy-imports.banned-api."typing.MutableMapping".msg = "Deprecated alias. Change to collections.abc.MutableMapping"
+lint.flake8-tidy-imports.banned-api."typing.Sequence".msg = "Deprecated alias. Change to collections.abc.Sequence"
+lint.flake8-tidy-imports.banned-api."typing.Set".msg = "Deprecated alias. Change to set"
+lint.flake8-tidy-imports.banned-api."typing.Tuple".msg = "Deprecated alias. Change to tuple"
+lint.flake8-tidy-imports.banned-api."typing.Type".msg = "Deprecated alias. Change to type"
+lint.isort.known-first-party = [ "pyfaradaycup" ]
+lint.pydocstyle.convention = "numpy"
+lint.pylint.max-positional-args = 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ format.line-ending = "lf"
 format.docstring-code-format = true
 # Using an IDE like PyCharm with a ruff plugin will make rule names appear as inlay hints
 lint.extend-select = [
+  # The commented out rulesets are to be enabled later
   # "A",
   # "ANN",
   "ARG",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,27 +56,27 @@ format.line-ending = "lf"
 format.docstring-code-format = true
 # Using an IDE like PyCharm with a ruff plugin will make rule names appear as inlay hints
 lint.extend-select = [
-  "A",
-  "ANN",
+  # "A",
+  # "ANN",
   "ARG",
   "ASYNC",
-  "B",
+  # "B",
   "BLE",
   "C4",
-  "C90",
+  # "C90",
   "COM",
-  "D",
+  # "D",
   "DTZ",
   "E",
-  "EM",
+  # "EM",
   "EXE",
   "F",
   "FA",
-  "FBT",
+  # "FBT",
   "FIX",
   "FLY",
-  "FURB",
-  "G",
+  # "FURB",
+  # "G",
   "I",
   "ICN",
   "INP",
@@ -86,18 +86,18 @@ lint.extend-select = [
   "N",
   "NPY",
   "PD",
-  "PERF",
+  # "PERF",
   "PGH",
   "PIE",
   "PLC",
   "PLE",
-  "PLR",
-  "PLW",
-  "PT",
-  "PTH",
+  # "PLR",
+  # "PLW",
+  # "PT",
+  # "PTH",
   "PYI",
   "Q",
-  "RET",
+  # "RET",
   "RSE",
   "RUF001",
   "RUF002",
@@ -150,37 +150,37 @@ lint.extend-select = [
   "RUF103",
   "RUF104",
   "RUF200",
-  "S",
+  # "S",
   "SIM",
   "SLF",
   "SLOT",
   "T10",
   "T20",
-  "TC",
+  # "TC",
   "TD",
-  "TID",
-  "TRY",
+  # "TID",
+  # "TRY",
   "UP",
   "W",
   "YTT",
 ]
 lint.ignore = [
-  "COM812",  # handled by ruff format
-  "COM819",  # adding trailing commas leads to simpler diffs
-  "D200",    # incompatible with multiline short summaries
-  "D203",    # handled by ruff format
-  "D205",    # incompatible with multiline short summaries
-  "D206",    # handled by ruff format
-  "D300",    # handled by ruff format
-  "E111",    # handled by ruff format
-  "E114",    # handled by ruff format
-  "E117",    # handled by ruff format
-  "E501",    # handled by ruff format
-  "Q001",    # handled by ruff format
-  "Q002",    # handled by ruff format
-  "Q003",    # handled by ruff format
-  "Q004",    # handled by ruff format
-  "W191",    # handled by ruff format
+  "COM812", # handled by ruff format
+  "COM819", # adding trailing commas leads to simpler diffs
+  "D200",   # incompatible with multiline short summaries
+  "D203",   # handled by ruff format
+  "D205",   # incompatible with multiline short summaries
+  "D206",   # handled by ruff format
+  "D300",   # handled by ruff format
+  "E111",   # handled by ruff format
+  "E114",   # handled by ruff format
+  "E117",   # handled by ruff format
+  "E501",   # handled by ruff format
+  "Q001",   # handled by ruff format
+  "Q002",   # handled by ruff format
+  "Q003",   # handled by ruff format
+  "Q004",   # handled by ruff format
+  "W191",   # handled by ruff format
 ]
 lint.extend-per-file-ignores."__init__.py" = [ "D104", "E402", "F401", "F402", "F403" ]  # ignore import errors
 lint.extend-per-file-ignores."tests/**/__init__.py" = [ "D104" ]

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -179,7 +179,6 @@ class BumpSinglePackage:
 
     def oldest_supported_release(self) -> str:
         """Get the oldest supported release of the package."""
-
         if not self.minor_releases:
             msg = f"[{self.name}] No minor releases identified."
             raise NoReleasesError(msg)
@@ -585,7 +584,6 @@ class BumpMinimumDependencies:
 
     def bump_groups(self) -> None:
         """Bump requirements in dependency groups."""
-
         msg = (
             "No dependency groups to update."
             if not self.groups_to_update

--- a/src/bump_minimum_dependencies/inputs.py
+++ b/src/bump_minimum_dependencies/inputs.py
@@ -41,7 +41,6 @@ class Inputs:
         verbosity: _VerbosityLiteral = "WARNING",
     ):
         """Put the inputs in a more usable form."""
-
         if only_group or only_extra:
             no_groups = True
             no_extras = True

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -158,7 +158,6 @@ def main(
     "Groups" refers to dependency groups while "extras" refers to
     categories of optional dependencies.
     """
-
     logger.setLevel(verbosity)
 
     if only_group or only_extra:

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -35,7 +35,7 @@ def get_errmsg_from_file_comparison(
             )
 
     if not error_messages:
-        return
+        return None
 
     expanded_comparison = (
         f"Mismatch between updated and expected pyproject.toml for {subdir = !r}.\n\n"

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -6,7 +6,7 @@ from packaging.requirements import Requirement
 from bump_minimum_dependencies.pyproject import PyProject
 
 
-@pytest.fixture()
+@pytest.fixture
 def simple_pyproject() -> PyProject:
     data_dir = Path(__file__).parent / "data"
     pyproject_file = data_dir / "simple_pyproject" / "pyproject.toml"


### PR DESCRIPTION
 - Enabled a bunch of rules for `ruff check`
 - Applied safe autofixes.
 - Commented out several rule sets that should be enabled later; many of these have unsafe autofixes that should go in dedicated PRs.