### PR TITLE
Make minor refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,21 @@ Automatically bumping minimum requirements in a predictable way saves time and b
 ```groff
 Usage: bump-minimum-dependencies [OPTIONS]
 
-  Bump minimum allowed versions of package dependencies in pyproject.toml.
+  Bump minimum versions of dependencies in pyproject.toml.
 
   This tool updates pyproject.toml via `uv add --frozen` to drop support for
   minor versions of package dependencies based on the time since the minor
   version was first released, where package versions may be given by
-  `<MAJOR>.<MINOR>` or `<MAJOR>.<MINOR>.<MICRO>`.
+  `<MAJOR>.<MINOR>` or `<MAJOR>.<MINOR>.<MICRO>`. Exact version specifiers and
+  upper limits are preserved.
 
-  When a `<MAJOR>.<MINOR>` release has numerous micro releases or for pre-1.0
-  releases, `<MICRO>` might also be bumped to the last release prior to the
-  drop date. Additional constraints such as upper limits are preserved.
+  For pre-1.0 version numbers or when a `<MAJOR>.<MINOR>` release has numerous
+  micro releases, `<MICRO>` will be bumped to the last micro release prior to
+  the drop date.
 
-  Requirements with markers or that cannot be updated will be skipped with a
-  warning.
+  Existing requirements will not be changed when the new minimum version is
+  incompatible with old requirements, a requirement has markers, or there are
+  multiple `!=` exclusions in the combined requirement.
 
   "Groups" refers to dependency groups while "extras" refers to categories of
   optional dependencies.

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -578,7 +578,6 @@ class BumpMinimumDependencies:
                 "uv",
                 "add",
                 "--frozen",
-                "--quiet",
                 *flag,
                 new_requirement,
             ]
@@ -587,8 +586,9 @@ class BumpMinimumDependencies:
             log_uv_command(command)
 
             try:
-                subprocess.run(command, check=True, capture_output=True)  # ruff:ignore[S603]
+                subprocess.run(command, check=True)  # ruff:ignore[S603]
             except subprocess.CalledProcessError as exc_info:
+                # logger.error(str(exc_info))
                 logger.error(
                     f"Command failed: {command_string}",
                     exc_info=exc_info,

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -589,7 +589,6 @@ class BumpMinimumDependencies:
             try:
                 subprocess.run(command, check=True)  # ruff:ignore[S603]
             except subprocess.CalledProcessError as exc_info:
-                # logger.error(str(exc_info))
                 logger.error(
                     f"Command failed: {command_string}",
                     exc_info=exc_info,

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -65,10 +65,8 @@ class BumpSinglePackage:
     @functools.cached_property
     def response_from_pypi(self) -> dict:
         """Representation of JSON file from PyPI."""
-        url =f"https://pypi.org/simple/{self.name}"
-        msg = (
-            f"{self.prefix} Retrieving package metadata from {url}"
-        )
+        url = f"https://pypi.org/simple/{self.name}"
+        msg = f"{self.prefix} Retrieving package metadata from {url}"
         logger.debug(msg)
         return requests.get(
             url=url,
@@ -570,7 +568,7 @@ class BumpMinimumDependencies:
 
         if not new_requirements:
             logger.info(f"No updates for {clause}.", extra={"markup": True})
-            return None
+            return
 
         for new_requirement in new_requirements:
             # Run a separate `uv add` command for each requirement

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -65,8 +65,13 @@ class BumpSinglePackage:
     @functools.cached_property
     def response_from_pypi(self) -> dict:
         """Representation of JSON file from PyPI."""
+        url =f"https://pypi.org/simple/{self.name}"
+        msg = (
+            f"{self.prefix} Retrieving package metadata from {url}"
+        )
+        logger.debug(msg)
         return requests.get(
-            url=f"https://pypi.org/simple/{self.name}",
+            url=url,
             headers={"Accept": "application/vnd.pypi.simple.v1+json"},
             timeout=10,
         ).json()

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -319,8 +319,9 @@ def get_new_requirement_for_package(
     """Combine the time-based requirement with the original requirement."""
     package = BumpSinglePackage(requirement.name, inputs=inputs)
     logger.debug(
-        f"{package_prefix(requirement.name)} Original specifier: {requirement.specifier!s}",
+        f"{package_prefix(requirement.name)} Original specifier: {requirement.specifier!r} {bool(requirement.specifier)}",
     )
+
     calculated_minimum_version = package.oldest_supported_release()
     time_based_requirement = f">={calculated_minimum_version}"
     logger.debug(
@@ -568,8 +569,8 @@ class BumpMinimumDependencies:
             clause = "project dependencies"
 
         if not new_requirements:
-            logger.info(f"No updates for for {clause}.", extra={"markup": True})
-            return
+            logger.info(f"No updates for {clause}.", extra={"markup": True})
+            return None
 
         for new_requirement in new_requirements:
             # Run a separate `uv add` command for each requirement
@@ -625,7 +626,6 @@ class BumpMinimumDependencies:
 
     def bump_extras(self) -> None:
         """Bump requirements in optional dependencies (extras)."""
-        logger.debug(f"extras_to_update: {self.extras_to_update}")
         for category in self.extras_to_update:
             requirements: set[Requirement] = self.pyproject.optional_dependencies[
                 category

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -164,7 +164,7 @@ class BumpSinglePackage:
         ) -> None:
             minor_date = self.versions_to_release_dates[minor_version].isoformat()
             micro_date = self.versions_to_release_dates[micro_version].isoformat()
-            logger.warning(
+            logger.info(
                 f"{self.prefix} Bumping micro version from "
                 f"{minor_version!s} ({minor_date}) to "
                 f"{micro_version!s} ({micro_date}) {reason}."

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -160,7 +160,7 @@ class BumpSinglePackage:
             minor_date = self.versions_to_release_dates[minor_version].isoformat()
             micro_date = self.versions_to_release_dates[micro_version].isoformat()
             logger.warning(
-                f"{self.prefix} Bumping version from "
+                f"{self.prefix} Bumping micro version from "
                 f"{minor_version!s} ({minor_date}) to "
                 f"{micro_version!s} ({micro_date}) {reason}."
             )

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -195,7 +195,7 @@ def main(  # ruff:ignore[PLR0913,PLR0917]
         verbosity=verbosity,
     )
 
-    logger.debug(f"{inputs = !s}" )
+    logger.debug(f"{inputs = !s}")
 
     bump_minimum_dependencies = bump.BumpMinimumDependencies(inputs=inputs)
     bump_minimum_dependencies.run()

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -141,20 +141,21 @@ def main(  # ruff:ignore[PLR0913,PLR0917]
     verbosity: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"],
 ) -> None:
     """
-    Bump minimum allowed versions of package dependencies in pyproject.toml.
+    Bump minimum versions of dependencies in pyproject.toml.
 
     This tool updates pyproject.toml via `uv add --frozen` to drop
     support for minor versions of package dependencies based on the time
     since the minor version was first released, where package versions
     may be given by `<MAJOR>.<MINOR>` or `<MAJOR>.<MINOR>.<MICRO>`.
+    Exact version specifiers and upper limits are preserved.
 
-    When a `<MAJOR>.<MINOR>` release has numerous micro releases or for
-    pre-1.0 releases, `<MICRO>` might also be bumped to the last release
-    prior to the drop date. Additional constraints such as upper limits
-    are preserved.
+    For pre-1.0 version numbers or when a `<MAJOR>.<MINOR>` release has
+    numerous micro releases, `<MICRO>` will be bumped to the last
+    micro release prior to the drop date.
 
-    Requirements with markers or that cannot be updated will be skipped
-    with a warning.
+    Existing requirements will not be changed when the new minimum
+    version is incompatible with old requirements, a requirement has
+    markers, or there are multiple `!=` exclusions in the combined
 
     "Groups" refers to dependency groups while "extras" refers to
     categories of optional dependencies.

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -156,6 +156,7 @@ def main(  # ruff:ignore[PLR0913,PLR0917]
     Existing requirements will not be changed when the new minimum
     version is incompatible with old requirements, a requirement has
     markers, or there are multiple `!=` exclusions in the combined
+    requirement.
 
     "Groups" refers to dependency groups while "extras" refers to
     categories of optional dependencies.

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -193,7 +193,7 @@ def main(  # ruff:ignore[PLR0913,PLR0917]
         verbosity=verbosity,
     )
 
-    logger.debug(str(inputs))
+    logger.debug(f"{inputs = !s}" )
 
     bump_minimum_dependencies = bump.BumpMinimumDependencies(inputs=inputs)
     bump_minimum_dependencies.run()


### PR DESCRIPTION
...including for the main docstring and logger/subprocess calls.  

A goal was to get uv error message to show up in the screen output, since when `uv add --frozen` has failed in tests and examples, it's usually because there's a problem with `pyproject.toml`.