### PR TITLE
Add `--dry-run` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Options:
   --skip-group TEXT               A dependency group to skip. Can use multiple
                                   times.
   --skip-core                     Do not update core project dependencies.
+  --dry-run                       Instead of performing updates, print the uv
+                                  commands that would be run.
   --verbosity [DEBUG|INFO|WARNING|ERROR|CRITICAL|NOTSET]
                                   Logging verbosity level.  [default: WARNING]
   --version                       Show the version and exit.

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -10,6 +10,7 @@ __all__ = [
 
 import datetime
 import functools
+import shlex
 import subprocess
 from typing import TYPE_CHECKING
 
@@ -581,8 +582,12 @@ class BumpMinimumDependencies:
                 new_requirement,
             ]
 
-            command_string = " ".join(command)
+            command_string = shlex.join(command)
             log_uv_command(command)
+
+            if self.inputs.dry_run:
+                click.echo(command_string)
+                continue
 
             try:
                 subprocess.run(command, check=True)  # ruff:ignore[S603]

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -316,12 +316,12 @@ def get_new_requirement_for_package(
     requirement: Requirement, inputs: Inputs
 ) -> str | None:
     """Combine the time-based requirement with the original requirement."""
-    package = BumpSinglePackage(requirement.name, inputs=inputs)
+    package_bumper = BumpSinglePackage(requirement.name, inputs=inputs)
     logger.debug(
         f"{package_prefix(requirement.name)} Original specifier: {requirement.specifier!r} {bool(requirement.specifier)}",
     )
 
-    calculated_minimum_version = package.oldest_supported_release()
+    calculated_minimum_version = package_bumper.oldest_supported_release()
     time_based_requirement = f">={calculated_minimum_version}"
     logger.debug(
         f"{package_prefix(requirement.name)} Time-based specifier: {time_based_requirement}",

--- a/src/bump_minimum_dependencies/inputs.py
+++ b/src/bump_minimum_dependencies/inputs.py
@@ -40,6 +40,7 @@ class Inputs:
         only_package: tuple[str, ...] | list[str] = (),
         skip_group: tuple[str, ...] | list[str] = (),
         skip_extra: tuple[str, ...] | list[str] = (),
+        dry_run: bool = False,
         verbosity: _VerbosityLiteral = "WARNING",
     ) -> None:
         """Put the inputs in a more usable form."""
@@ -62,6 +63,7 @@ class Inputs:
         self.extras_to_skip: set[str] = _make_lower_case_set(skip_extra)
         self.groups_to_update: set[str] = _make_lower_case_set(only_group)
         self.groups_to_skip: set[str] = _make_lower_case_set(skip_group)
+        self.dry_run = dry_run
 
     def __str__(self) -> str:
         """Stringify the inputs, as stored."""

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -130,14 +130,15 @@ from bump_minimum_dependencies.logging import logger
 )
 @click.version_option(package_name="bump_minimum_dependencies")
 @click.pass_context
-def main(  # ruff:ignore[PLR0913,PLR0917]
+def main(  # ruff:ignore[PLR0913]
     ctx: click.Context,
+    *,
     pyproject_file: str | pathlib.Path,
     drop_months: float,
     cooldown_months: float,
-    no_extras: bool,  # ruff:ignore[FBT001]
-    no_groups: bool,  # ruff:ignore[FBT001]
-    skip_core: bool,  # ruff:ignore[FBT001]
+    no_extras: bool,
+    no_groups: bool,
+    skip_core: bool,
     only_extra: tuple[str, ...] | list[str],
     only_group: tuple[str, ...] | list[str],
     skip_package: tuple[str, ...] | list[str],

--- a/src/bump_minimum_dependencies/main.py
+++ b/src/bump_minimum_dependencies/main.py
@@ -115,6 +115,12 @@ from bump_minimum_dependencies.logging import logger
     help="Do not update core project dependencies.",
 )
 @click.option(
+    "--dry-run",
+    default=False,
+    is_flag=True,
+    help="Instead of performing updates, print the uv commands that would be run.",
+)
+@click.option(
     "--verbosity",
     default="WARNING",
     type=click.Choice(
@@ -138,6 +144,7 @@ def main(  # ruff:ignore[PLR0913,PLR0917]
     only_package: tuple[str, ...] | list[str],
     skip_group: tuple[str, ...] | list[str],
     skip_extra: tuple[str, ...] | list[str],
+    dry_run: bool,
     verbosity: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NOTSET"],
 ) -> None:
     """
@@ -193,6 +200,7 @@ def main(  # ruff:ignore[PLR0913,PLR0917]
         skip_group=skip_group,
         skip_package=skip_package,
         verbosity=verbosity,
+        dry_run=dry_run,
     )
 
     logger.debug(f"{inputs = !s}")

--- a/tests/data/dry_run/pyproject.expected.toml
+++ b/tests/data/dry_run/pyproject.expected.toml
@@ -1,0 +1,25 @@
+[build-system]
+build-backend = "uv_build"
+requires = [ "uv-build>=0.12.2,<0.13" ]
+
+[project]
+name = "bump-only-package"
+version = "0.1.0"
+requires-python = ">=3.13"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
+]
+dependencies = [
+  "numpy>=1.15",
+]
+optional-dependencies.extra = [
+  "numpy>=1.15",
+]
+
+[dependency-groups]
+update = [
+  "numpy>=1.15",
+]

--- a/tests/data/dry_run/pyproject.toml
+++ b/tests/data/dry_run/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+build-backend = "uv_build"
+requires = [ "uv-build>=0.12.2,<0.13" ]
+
+[project]
+name = "bump-only-package"
+version = "0.1.0"
+requires-python = ">=3.13"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
+]
+dependencies = [
+  "numpy>=1.15",
+]
+optional-dependencies.extra = [
+  "numpy>=1.15",
+]
+
+[dependency-groups]
+update = [
+  "numpy>=1.15",
+]

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -251,6 +251,7 @@ def get_errmsg_from_file_comparison(  # ruff:ignore[D103]
                 "verbosity": DEFAULT_TEST_VERBOSITY,
             },
         ),
+        ("dry_run", "2026-08-18", {"dry_run": True}),
     ],
 )
 def test_bumping_minimum_requirements(  # ruff:ignore[D103,PLR0913]


### PR DESCRIPTION
If `--dry-run` is used, the `uv add` command will be printed to stdout rather than being run.

I also made most arguments to `main()` keyword-only.  This _shouldn't_ cause problems. 😅