### PR TITLE
Use exception handling for requirements with multiple `!=` specifiers that cannot be updated

### DIFF
--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -42,6 +42,7 @@ class BrokenSpecifierError(Exception):
     multiple `!=` specifiers.
     """
 
+
 class BumpSinglePackage:
     """
     A class used to bump minimum dependencies for a Python package.
@@ -288,15 +289,19 @@ def combine_requirements(
     """
     parsed_original = parse_version_specifier(str(original))
     parsed_new = parse_version_specifier(str(new))
+
     if parsed_new == parsed_original:
         return str(original)
+
     combined = parsed_original & parsed_new
     new_specifier = str(original) if combined.is_empty() else str(combined)
+
     if "||" in new_specifier:
-        logger.warning(
-            "Cannot update versions with multiple != in supported range. Skipping.",
+        msg = (
+            "Cannot update versions with multiple != specifiers in "
+            "the combined requirement due to limitations in dep_logic."
         )
-        raise BrokenSpecifierError
+        raise BrokenSpecifierError(msg)
 
     return utils.normalize_requirement_string(new_specifier)
 
@@ -524,21 +529,29 @@ class BumpMinimumDependencies:
                     inputs=inputs,
                 )
             except NoReleasesError:
-                logger.warning(
-                    f"{package_prefix(requirement.name)} No releases identified from PyPI. Skipping.",
+                msg = (
+                    f"{package_prefix(requirement.name)} "
+                    f"No releases identified from PyPI. Skipping."
                 )
+                logger.warning(msg)
             except requests.exceptions.JSONDecodeError:
-                logger.warning(
-                    f"{package_prefix(requirement.name)} Cannot decode JSON metadata from "
-                    f"PyPI. Skipping.",
+                msg = (
+                    f"{package_prefix(requirement.name)} Cannot decode "
+                    f"JSON metadata from PyPI. Skipping."
                 )
+                logger.warning(msg)
+            except BrokenSpecifierError:
+                # See https://github.com/pdm-project/dep-logic/issues/20
+                msg = (
+                    f"{package_prefix(requirement.name)} Unable to update requirements "
+                    f"with multiple != specifiers. Skipping."
+                )
+                logger.warning(msg)
             # Catch all other exceptions since if a package cannot be updated
             # for whatever reason, it should be skipped with a warning issued.
             except Exception as exc_info:  # ruff:ignore[BLE001]
-                warning_message = (
-                    f"{package_prefix(requirement.name)} Unable to update requirement. Skipping.",
-                )
-                logger.error(warning_message, exc_info=exc_info, extra={"markup": True})
+                msg = f"{package_prefix(requirement.name)} Unable to update requirement. Skipping."
+                logger.error(msg, exc_info=exc_info, extra={"markup": True})
             else:
                 if not new_requirement:
                     continue

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -33,6 +33,14 @@ class NoReleasesError(Exception):
     """When no releases of a package can be identified."""
 
 
+class BrokenSpecifierError(Exception):
+    """
+    When a specifier coming out of dep_logic is invalid.
+
+    This is used when there is a `||` in the specifier set related to
+    multiple `!=` specifiers.
+    """
+
 class BumpSinglePackage:
     """
     A class used to bump minimum dependencies for a Python package.
@@ -287,7 +295,7 @@ def combine_requirements(
         logger.warning(
             "Cannot update versions with multiple != in supported range. Skipping.",
         )
-        return str(original)
+        raise BrokenSpecifierError
 
     return utils.normalize_requirement_string(new_specifier)
 

--- a/src/bump_minimum_dependencies/bump.py
+++ b/src/bump_minimum_dependencies/bump.py
@@ -272,7 +272,7 @@ class BumpSinglePackage:
 def combine_requirements(
     original: packaging.specifiers.SpecifierSet,
     new: str,
-) -> str | None:
+) -> str:
     """
     Combine two version specifiers, falling back to `original` if the
     two specifiers are mutually incompatible.
@@ -287,7 +287,7 @@ def combine_requirements(
         logger.warning(
             "Cannot update versions with multiple != in supported range. Skipping.",
         )
-        return None
+        return str(original)
 
     return utils.normalize_requirement_string(new_specifier)
 

--- a/tests/data/basic_24_21/pyproject.expected.toml
+++ b/tests/data/basic_24_21/pyproject.expected.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
   "astropy>=6",
+  "distlib>=0.4.2,!=0.4.3,!=0.4.4",  # https://github.com/pdm-project/dep-logic/issues/20
   "docutils>=0.20.1,<2",  # bump micro version
   "heliopy>=1,<2",
   "nose~=1.0.0",

--- a/tests/data/basic_24_21/pyproject.toml
+++ b/tests/data/basic_24_21/pyproject.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
   "astropy",
+  "distlib>=0.4.2,!=0.4.3,!=0.4.4",  # https://github.com/pdm-project/dep-logic/issues/20
   "docutils!=0.19,<2",  # bump micro version
   "heliopy<2",
   "nose~=1.0.0",


### PR DESCRIPTION
I noticed that when attempting to bump `"distlib>=0.4.2,!=0.4.3,!=0.4.4"`, the `uv add` command was attempting to bump `distlibNone`. 🥲  This came down to old behavior in `bump.combine_requirements()` where `None` was converted into a string in place of a specifier.  This PR uses exception handling to handle when there are multiple `!=` specifiers in a much cleaner way.

See also #58. 